### PR TITLE
fix: handle CORS origin dynamically

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,14 +17,16 @@ async function bootstrap() {
   });
 
   const corsOptions = {
-    "origin": "*",
-    "methods": "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS",
-    "preflightContinue": false,
-    "optionsSuccessStatus": 204,
-    "credentials":true,
-    "allowedHeaders": 'Content-Type, Authorization, Accept, Observe,  api_key',
-    "exposedHeaders":"Pagination-Count, Pagination-Page, Pagination-Limit, Query-Version"
-  }
+    origin: (origin, callback) => {
+      callback(null, origin || true);
+    },
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    preflightContinue: false,
+    optionsSuccessStatus: 204,
+    credentials: true,
+    allowedHeaders: 'Content-Type, Authorization, Accept, Observe,  api_key',
+    exposedHeaders: 'Pagination-Count, Pagination-Page, Pagination-Limit, Query-Version',
+  };
   app.enableCors(corsOptions);
   app.useGlobalPipes(new ValidationPipe({transform: true}));
 


### PR DESCRIPTION
## Summary
- replace `origin: '*'` with function that echoes request origin so credentials can be used

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test`
- `npm start` (manually tested CORS headers via curl)


------
https://chatgpt.com/codex/tasks/task_e_68a06a3139f48326bc5c775ab314ea64