### PR TITLE
feat: add GCS fallback for cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ curl -H "x-api-key: DEMO-API-KEY" -X GET -G 'http://localhost:8080/places/brands
 -d 'country=AU' -d 'categories=airlines,airline'
 ```
 
+### Caching
+
+The application uses a hybrid cache layer to reduce calls to external services.
+
+- `REDIS_URL` &mdash; optional Redis connection string (e.g. `redis://localhost:6379`).
+- `CACHE_MAX_OBJECT_BYTES` &mdash; maximum payload size (defaults to ~1&nbsp;MB). Objects larger than this spill to GCS.
+- `GCS_BUCKET` &mdash; when set, large objects or instances without Redis are written to this bucket using the same cache interface. Ensure standard GCS authentication variables are configured.
+- When neither Redis nor `GCS_BUCKET` are configured, the in-memory store is used exclusively.
+- Cached entries currently have a default TTL of 3600 seconds (1 hour). GCS objects persist until explicitly deleted or lifecycle rules are applied.
+
 
 #### Credits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage": "^7.13.0",
+        "@nestjs/cache-manager": "^3.0.1",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.3",
         "@nestjs/core": "^10.0.0",
@@ -18,6 +19,8 @@
         "@nestjs/swagger": "^8.0.1",
         "@turf/turf": "^7.1.0",
         "@types/geojson": "^7946.0.14",
+        "cache-manager": "^7.1.1",
+        "cache-manager-redis-yet": "^5.1.5",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "dotenv": "^16.4.5",
@@ -1863,6 +1866,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
+      "license": "MIT"
+    },
     "node_modules/@ljharb/through": {
       "version": "2.3.13",
       "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
@@ -1889,6 +1898,19 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
       "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA=="
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-3.0.1.tgz",
+      "integrity": "sha512-4UxTnR0fsmKL5YDalU2eLFVnL+OBebWUpX+hEduKGncrVKH4PPNoiRn1kXyOCjmzb0UvWgqubpssNouc8e0MCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "cache-manager": ">=6",
+        "keyv": ">=5",
+        "rxjs": "^7.8.1"
+      }
     },
     "node_modules/@nestjs/cli": {
       "version": "10.4.5",
@@ -2366,6 +2388,71 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5726,6 +5813,56 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cache-manager": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.1.1.tgz",
+      "integrity": "sha512-YZ5CXZ4cNOcVH5bokYE1Bo5NARvJhOkYAAwImGf7DozC0uyrT5Jqd5AWfPnSRavlHTPiHp2yZL3Q3ZEWBfkQvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyv": "^5.5.0"
+      }
+    },
+    "node_modules/cache-manager-redis-yet": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/cache-manager-redis-yet/-/cache-manager-redis-yet-5.1.5.tgz",
+      "integrity": "sha512-NYDxrWBoLXxxVPw4JuBriJW0f45+BVOAsgLiozRo4GoJQyoKPbueQWYStWqmO73/AeHJeWrV7Hzvk6vhCGHlqA==",
+      "deprecated": "With cache-manager v6 we now are using Keyv",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "^1.2.0",
+        "@redis/client": "^1.6.0",
+        "@redis/graph": "^1.1.1",
+        "@redis/json": "^1.0.7",
+        "@redis/search": "^1.2.0",
+        "@redis/time-series": "^1.1.0",
+        "cache-manager": "^5.7.6",
+        "redis": "^4.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cache-manager-redis-yet/node_modules/cache-manager": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-5.7.6.tgz",
+      "integrity": "sha512-wBxnBHjDxF1RXpHCBD6HGvKER003Ts7IIm0CHpggliHzN1RZditb7rXoduE1rplc2DEFYKxhLKgFuchXMJje9w==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^10.2.2",
+        "promise-coalesce": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cache-manager-redis-yet/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -5987,6 +6124,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -6970,6 +7116,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -7352,6 +7504,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
@@ -7599,6 +7761,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -9359,13 +9530,12 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
+      "integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.0"
       }
     },
     "node_modules/kleur": {
@@ -9445,6 +9615,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -10375,6 +10551,15 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/promise-coalesce": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/promise-coalesce/-/promise-coalesce-1.1.2.tgz",
+      "integrity": "sha512-zLaJ9b8hnC564fnJH6NFSOGZYYdzrAJn2JUUIwzoQb32fG2QAakpDNM+CZo1km6keXkRXRM+hml1BFAPVnPkxg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10564,6 +10749,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage": "^7.13.0",
+    "@nestjs/cache-manager": "^3.0.1",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
@@ -29,6 +30,8 @@
     "@nestjs/swagger": "^8.0.1",
     "@turf/turf": "^7.1.0",
     "@types/geojson": "^7946.0.14",
+    "cache-manager": "^7.1.1",
+    "cache-manager-redis-yet": "^5.1.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "export $(cat .env.test | xargs) && NODE_ENV=test && jest --config ./test/jest-e2e.json"
+    "test:e2e": "bash -c 'if [ -f .env.test ]; then export $(cat .env.test | xargs); fi; NODE_ENV=test jest --config ./test/jest-e2e.json'"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^7.9.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,11 +8,11 @@ import { Request, Response } from 'express';
 import { AuthAPIMiddleware } from './middleware/auth-api.middleware';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { CacheModule } from './cache/cache.module';
+import { AppCacheModule } from './cache/cache.module';
 
 @Module({
   imports: [
-    CacheModule,
+    AppCacheModule,
     BuildingsModule,
     PlacesModule,
     ConfigModule.forRoot(),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,23 +1,22 @@
-import { CloudstorageCacheModule } from './cloudstorage-cache/cloudstorage-cache.module';
+import { Module, NestMiddleware, MiddlewareConsumer, Logger } from '@nestjs/common';
 import { BuildingsModule } from './buildings/buildings.module';
 import { PlacesModule } from './places/places.module';
-import { PlacesService } from './places/places.service';
-
-import { Module, NestMiddleware, MiddlewareConsumer, Logger, RequestMethod } from '@nestjs/common';
-import { PlacesController } from './places/places.controller';
 import { BigQueryService } from './bigquery/bigquery.service';
 import { GcsService } from './gcs/gcs.service';
 import { ConfigModule } from '@nestjs/config';
-import { Request, Response } from 'express'
+import { Request, Response } from 'express';
 import { AuthAPIMiddleware } from './middleware/auth-api.middleware';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { CacheModule } from './cache/cache.module';
 
 @Module({
   imports: [
-    CloudstorageCacheModule,
+    CacheModule,
     BuildingsModule,
-    PlacesModule, ConfigModule.forRoot()],
+    PlacesModule,
+    ConfigModule.forRoot(),
+  ],
   controllers: [AppController],
   providers: [BigQueryService, GcsService, AppService],
 })

--- a/src/cache/cache.constants.ts
+++ b/src/cache/cache.constants.ts
@@ -1,0 +1,8 @@
+export interface CacheConfig {
+  redisUrl?: string;
+  maxObjectBytes: number;
+  gcsBucket?: string;
+}
+
+export const CACHE_CONFIG = 'CACHE_CONFIG';
+export const GCS_BUCKET = 'GCS_BUCKET';

--- a/src/cache/cache.module.ts
+++ b/src/cache/cache.module.ts
@@ -4,19 +4,12 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { redisStore } from 'cache-manager-redis-yet';
 import { Storage, Bucket } from '@google-cloud/storage';
 import { CacheService } from './cache.service';
-
-export interface CacheConfig {
-  redisUrl?: string;
-  maxObjectBytes: number;
-  gcsBucket?: string;
-}
-
-export const CACHE_CONFIG = 'CACHE_CONFIG';
-export const GCS_BUCKET = 'GCS_BUCKET';
+import { CACHE_CONFIG, GCS_BUCKET, CacheConfig } from './cache.constants';
 
 @Global()
 @Module({
   imports: [
+    ConfigModule,
     NestCacheModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -58,6 +51,6 @@ export const GCS_BUCKET = 'GCS_BUCKET';
     },
     CacheService,
   ],
-  exports: [CacheService, NestCacheModule, CACHE_CONFIG],
+  exports: [CacheService, CACHE_CONFIG],
 })
-export class CacheModule {}
+export class AppCacheModule {}

--- a/src/cache/cache.module.ts
+++ b/src/cache/cache.module.ts
@@ -1,0 +1,63 @@
+import { Module, Global } from '@nestjs/common';
+import { CacheModule as NestCacheModule } from '@nestjs/cache-manager';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { redisStore } from 'cache-manager-redis-yet';
+import { Storage, Bucket } from '@google-cloud/storage';
+import { CacheService } from './cache.service';
+
+export interface CacheConfig {
+  redisUrl?: string;
+  maxObjectBytes: number;
+  gcsBucket?: string;
+}
+
+export const CACHE_CONFIG = 'CACHE_CONFIG';
+export const GCS_BUCKET = 'GCS_BUCKET';
+
+@Global()
+@Module({
+  imports: [
+    NestCacheModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => {
+        const redisUrl = configService.get<string>('REDIS_URL');
+        if (redisUrl) {
+          return {
+            store: await redisStore({ url: redisUrl }),
+          };
+        }
+        return {};
+      },
+    }),
+  ],
+  providers: [
+    {
+      provide: CACHE_CONFIG,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService): CacheConfig => ({
+        redisUrl: configService.get<string>('REDIS_URL'),
+        maxObjectBytes: configService.get<number>(
+          'CACHE_MAX_OBJECT_BYTES',
+          1_000_000,
+        ),
+        gcsBucket: configService.get<string>('GCS_BUCKET'),
+      }),
+    },
+    {
+      provide: GCS_BUCKET,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService): Bucket | null => {
+        const bucketName = configService.get<string>('GCS_BUCKET');
+        if (bucketName) {
+          const storage = new Storage();
+          return storage.bucket(bucketName);
+        }
+        return null;
+      },
+    },
+    CacheService,
+  ],
+  exports: [CacheService, NestCacheModule, CACHE_CONFIG],
+})
+export class CacheModule {}

--- a/src/cache/cache.service.spec.ts
+++ b/src/cache/cache.service.spec.ts
@@ -1,0 +1,95 @@
+import { CacheService } from './cache.service';
+import { CACHE_CONFIG, GCS_BUCKET, CacheConfig } from './cache.module';
+import { Cache } from 'cache-manager';
+import { Bucket } from '@google-cloud/storage';
+
+// simple in-memory cache mock
+function createCache(): { store: Map<string, any>; cache: Cache } {
+  const store = new Map<string, any>();
+  const cache: Cache = {
+    get: async (key: string) => store.get(key),
+    set: async (key: string, value: any) => {
+      store.set(key, value);
+    },
+    del: async (key: string) => {
+      store.delete(key);
+    },
+  } as any;
+  return { store, cache };
+}
+
+// simple GCS bucket mock
+function createBucket() {
+  const gcsStore = new Map<string, Buffer>();
+  const bucket: Bucket = {
+    file: (name: string) => ({
+      save: async (data: string | Buffer) => {
+        const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+        gcsStore.set(name, buf);
+      },
+      download: async () => [gcsStore.get(name) as Buffer],
+      delete: async () => {
+        gcsStore.delete(name);
+      },
+    }) as any,
+  } as any;
+  return { bucket, gcsStore };
+}
+
+describe('CacheService hybrid storage', () => {
+  it('stores small payload in cache when redis configured', async () => {
+    const { store, cache } = createCache();
+    const { bucket, gcsStore } = createBucket();
+    const config: CacheConfig = {
+      redisUrl: 'redis://example',
+      maxObjectBytes: 1000,
+      gcsBucket: 'bucket',
+    };
+    const service = new CacheService(cache, config, bucket);
+    const value = { foo: 'bar' };
+
+    await service.set('key', value);
+    expect(store.get('key')).toEqual(value);
+    expect(gcsStore.size).toBe(0);
+    await service.del('key');
+    expect(store.has('key')).toBe(false);
+  });
+
+  it('stores large payloads in GCS when size exceeds threshold', async () => {
+    const { store, cache } = createCache();
+    const { bucket, gcsStore } = createBucket();
+    const config: CacheConfig = {
+      redisUrl: 'redis://example',
+      maxObjectBytes: 10,
+      gcsBucket: 'bucket',
+    };
+    const service = new CacheService(cache, config, bucket);
+    const value = { foo: 'a'.repeat(50) };
+
+    await service.set('key', value);
+    expect(store.get('key')).toEqual({ gcs: true });
+    expect(gcsStore.size).toBe(1);
+    const fetched = await service.get<typeof value>('key');
+    expect(fetched).toEqual(value);
+    await service.del('key');
+    expect(gcsStore.size).toBe(0);
+  });
+
+  it('stores payloads in GCS when redis is absent', async () => {
+    const { store, cache } = createCache();
+    const { bucket, gcsStore } = createBucket();
+    const config: CacheConfig = {
+      maxObjectBytes: 1000,
+      gcsBucket: 'bucket',
+    };
+    const service = new CacheService(cache, config, bucket);
+    const value = { foo: 'bar' };
+
+    await service.set('key', value);
+    expect(store.get('key')).toEqual({ gcs: true });
+    const fetched = await service.get<typeof value>('key');
+    expect(fetched).toEqual(value);
+    await service.del('key');
+    expect(gcsStore.size).toBe(0);
+  });
+});

--- a/src/cache/cache.service.spec.ts
+++ b/src/cache/cache.service.spec.ts
@@ -1,5 +1,5 @@
 import { CacheService } from './cache.service';
-import { CACHE_CONFIG, GCS_BUCKET, CacheConfig } from './cache.module';
+import { CacheConfig } from './cache.constants';
 import { Cache } from 'cache-manager';
 import { Bucket } from '@google-cloud/storage';
 

--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -1,0 +1,56 @@
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { Bucket } from '@google-cloud/storage';
+import { CACHE_CONFIG, GCS_BUCKET, CacheConfig } from './cache.module';
+
+@Injectable()
+export class CacheService {
+  constructor(
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    @Inject(CACHE_CONFIG) private config: CacheConfig,
+    @Optional() @Inject(GCS_BUCKET) private bucket?: Bucket | null,
+  ) {}
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const entry = await this.cacheManager.get<any>(key);
+    if (!entry) {
+      return undefined;
+    }
+    if (entry?.gcs && this.bucket) {
+      const [data] = await this.bucket.file(key).download();
+      return JSON.parse(data.toString()) as T;
+    }
+    return entry as T;
+  }
+
+  async set<T>(key: string, value: T, ttl?: number): Promise<void> {
+    const serialized = JSON.stringify(value);
+    const byteLength = Buffer.byteLength(serialized);
+    const canUseCache =
+      !!this.config.redisUrl && byteLength <= this.config.maxObjectBytes;
+
+    if (canUseCache) {
+      await this.cacheManager.set(key, value, ttl);
+      return;
+    }
+
+    if (this.bucket) {
+      await this.bucket.file(key).save(serialized, { resumable: false });
+      await this.cacheManager.set(key, { gcs: true }, ttl);
+      return;
+    }
+
+    await this.cacheManager.set(key, value, ttl);
+  }
+
+  async del(key: string): Promise<void> {
+    const entry = await this.cacheManager.get<any>(key);
+    await this.cacheManager.del(key);
+    if (entry?.gcs && this.bucket) {
+      try {
+        await this.bucket.file(key).delete();
+      } catch {}
+    }
+  }
+}

--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Optional } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { Bucket } from '@google-cloud/storage';
-import { CACHE_CONFIG, GCS_BUCKET, CacheConfig } from './cache.module';
+import { CACHE_CONFIG, GCS_BUCKET, CacheConfig } from './cache.constants';
 
 @Injectable()
 export class CacheService {

--- a/src/places/places.module.ts
+++ b/src/places/places.module.ts
@@ -6,15 +6,13 @@ import { Module } from '@nestjs/common';
 import { PlacesService } from './places.service';
 import { PlacesController } from './places.controller';
 import { BigQueryService } from '../bigquery/bigquery.service';
-import { GcsService } from '../gcs/gcs.service';
 import { ConfigModule } from '@nestjs/config';
-import { CloudstorageCacheModule } from '../cloudstorage-cache/cloudstorage-cache.module';
 import { BuildingsModule } from '../buildings/buildings.module';
 
 @Module({
-    imports: [ConfigModule, CloudstorageCacheModule, BuildingsModule],
+    imports: [ConfigModule, BuildingsModule],
     controllers: [PlacesController],
-    providers: [PlacesService, BigQueryService, GcsService],
+    providers: [PlacesService, BigQueryService],
     exports: [PlacesService]
 
 })

--- a/src/places/places.service.ts
+++ b/src/places/places.service.ts
@@ -4,7 +4,6 @@ https://docs.nestjs.com/providers#services
 
 import { Injectable, Logger } from '@nestjs/common';
 import { BigQueryService } from '../bigquery/bigquery.service';
-import { GcsService } from '../gcs/gcs.service';
 import { GetPlacesDto } from './dto/requests/get-places.dto';
 import { PlaceResponseDto, toPlaceDto } from './dto/responses/place-response.dto';
 import { GetBrandsDto } from './dto/requests/get-brands.dto';
@@ -18,7 +17,7 @@ import { AuthedUser, User } from '../decorators/authed-user.decorator';
 import { ValidateLatLngUser } from '../decorators/validate-lat-lng-user.decorator';
 import { Place, PlaceWithBuilding } from './interfaces/place.interface';
 import { ConfigService } from '@nestjs/config';
-import { CloudStorageCacheService } from '../cloudstorage-cache/cloudstorage-cache.service';
+import { CacheService } from '../cache/cache.service';
 import { GetPlacesWithBuildingsDto } from './dto/requests/get-places-with-buildings';
 
 @Injectable()
@@ -27,20 +26,17 @@ export class PlacesService {
     
     constructor(
         private readonly configService: ConfigService,
-      private readonly bigQueryService: BigQueryService,
-      private readonly cloudStorageCache: CloudStorageCacheService,
+        private readonly bigQueryService: BigQueryService,
+        private readonly cacheService: CacheService,
     ) {}
     async getPlaces(query: GetPlacesDto):Promise<Place[]> {
 
         const { lat, lng, radius,  country, min_confidence, brand_wikidata,brand_name,categories,limit, source } = query;
         const cacheKey = `get-places-${JSON.stringify(query)}`;
-        // Check if cached results exist in GCS
-        let results:Place[] = await this.cloudStorageCache.getJSON(cacheKey);
+        let results: Place[] | undefined = await this.cacheService.get<Place[]>(cacheKey);
         if (!results) {
-          // If no cache, query BigQuery with wikidata and country support
-          results = await this.bigQueryService.getPlacesNearby(lat, lng, radius, brand_wikidata,brand_name, country, categories, min_confidence,limit);
-          // Cache the results in GCS
-          await this.cloudStorageCache.storeJSON (results,cacheKey);
+          results = await this.bigQueryService.getPlacesNearby(lat, lng, radius, brand_wikidata, brand_name, country, categories, min_confidence, limit);
+          await this.cacheService.set(cacheKey, results, 3600);
         }
         // Filter by source if provided
         if (source) {
@@ -55,59 +51,53 @@ export class PlacesService {
         const { lat, lng, radius, country, min_confidence, brand_wikidata,brand_name,categories,limit, match_nearest_building} = query;
     
         const cacheKey = `get-places-${JSON.stringify(query)}`;
-    
-        // Check if cached results exist in GCS
-        let results:PlaceWithBuilding[] = await this.cloudStorageCache.getJSON(cacheKey);
+        let results: PlaceWithBuilding[] | undefined = await this.cacheService.get<PlaceWithBuilding[]>(cacheKey);
         if (!results) {
-          // If no cache, query BigQuery with wikidata and country support
-          results = await this.bigQueryService.getPlacesWithNearestBuilding(lat, lng, radius,  brand_wikidata,brand_name, country, categories, min_confidence,limit, match_nearest_building );
-          // Cache the results in GCS
-          await this.cloudStorageCache.storeJSON (results,cacheKey);
-    
+          results = await this.bigQueryService.getPlacesWithNearestBuilding(lat, lng, radius, brand_wikidata, brand_name, country, categories, min_confidence, limit, match_nearest_building);
+          await this.cacheService.set(cacheKey, results, 3600);
         }
-          return results
+        return results;
         
       }
 
     async getBrands(query: GetBrandsDto): Promise<BrandDto[]> {
         const { country, lat, lng, radius, categories } = query;
   
-        // Check if cached results exist in GCS
         const cacheKey = `get-places-brands-${JSON.stringify(query)}`;
-        const cachedResult = await this.cloudStorageCache.getJSON(cacheKey);
+        const cachedResult = await this.cacheService.get<any[]>(cacheKey);
         if (cachedResult) {
           return cachedResult;
         }
-      
+
         const results = await this.bigQueryService.getBrandsNearby(country, lat, lng, radius, categories);
-        await this.cloudStorageCache.storeJSON (results,cacheKey);
+        await this.cacheService.set(cacheKey, results, 3600);
         return results.map((brand: any) => new BrandDto(brand));
       }
 
     async getCountries():Promise<CountryResponseDto[]> {
         const cacheKey = `get-places-countries`;
-        const cachedResult = await this.cloudStorageCache.getJSON(cacheKey);
+        const cachedResult = await this.cacheService.get<any[]>(cacheKey);
         if (cachedResult) {
           return cachedResult;
         }
 
         const results = await this.bigQueryService.getPlaceCountsByCountry();
-        await this.cloudStorageCache.storeJSON (results,cacheKey);
+        await this.cacheService.set(cacheKey, results, 3600);
         return results.map((country: any) => toCountryResponseDto(country));
     }
 
     async getCategories(query: GetCategoriesDto): Promise<CategoryResponseDto[]> {
 
         const cacheKey = `get-places-categories-${JSON.stringify(query)}`;
-          const cachedResult = await this.cloudStorageCache.getJSON(cacheKey );
-          if (cachedResult) {
-            return cachedResult;
-          }
-          
-          const results = await this.bigQueryService.getCategories(query.country, query.lat, query.lng, query.radius);
-          
-          await this.cloudStorageCache.storeJSON (results, cacheKey);
-            return results.map((category: any) => toCategoryResponseDto(category));
+        const cachedResult = await this.cacheService.get<any[]>(cacheKey);
+        if (cachedResult) {
+          return cachedResult;
+        }
+
+        const results = await this.bigQueryService.getCategories(query.country, query.lat, query.lng, query.radius);
+
+        await this.cacheService.set(cacheKey, results, 3600);
+        return results.map((category: any) => toCategoryResponseDto(category));
       }
 
 }


### PR DESCRIPTION
## Summary
- add cache config and optional GCS bucket to cache module
- implement size-aware cache service that stores large entries in GCS when Redis is absent or payload is too big
- document hybrid caching env vars and add unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1370b3424832682d54307e52ac1fe