### PR TITLE
Harden auth handling and query cost controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^8.0.1",
+        "@nestjs/throttler": "^5.2.0",
         "@turf/turf": "^7.1.0",
         "@types/geojson": "^7946.0.14",
         "cache-manager": "^7.1.1",
@@ -2115,6 +2116,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-5.2.0.tgz",
+      "integrity": "sha512-G/G/MV3xf6sy1DwmnJsgeL+d2tQ/xGRNa9ZhZjm9Kyxp+3+ylGzwJtcnhWlN82PMEp3TiDQpTt+9waOIg/bpPg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^8.0.1",
+    "@nestjs/throttler": "^5.2.0",
     "@turf/turf": "^7.1.0",
     "@types/geojson": "^7946.0.14",
     "cache-manager": "^7.1.1",

--- a/src/addresses/addresses.controller.ts
+++ b/src/addresses/addresses.controller.ts
@@ -7,11 +7,12 @@ import { Format } from '../common/dto/requests/get-by-location.dto';
 import { ApiSecurity, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CountHeader } from '../decorators/count-header.decorator';
 import { IsAuthenticatedGuard } from '../guards/is-authenticated.guard';
+import { DemoLocationGuard } from '../guards/demo-location.guard';
 
 @ApiTags('Addresses')
 @ApiSecurity('API_KEY')
 @Controller('addresses')
-@UseGuards(IsAuthenticatedGuard)
+@UseGuards(IsAuthenticatedGuard, DemoLocationGuard)
 export class AddressesController {
 
     logger = new Logger('AddressesController');

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,8 @@ import { DivisionsModule } from './divisions/divisions.module';
 import { BigQueryService } from './bigquery/bigquery.service';
 import { GcsService } from './gcs/gcs.service';
 import { ConfigModule } from '@nestjs/config';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { Request, Response } from 'express';
 import { AuthAPIMiddleware } from './middleware/auth-api.middleware';
 import { AppController } from './app.controller';
@@ -24,9 +26,22 @@ import { AppCacheModule } from './cache/cache.module';
     TransportationModule,
     DivisionsModule,
     ConfigModule.forRoot(),
+    // Per-client rate limiting. Each BigQuery-backed request can cost real money,
+    // so cap request volume. Overridable via env without a redeploy.
+    ThrottlerModule.forRoot([
+      {
+        ttl: parseInt(process.env.THROTTLE_TTL_MS || '60000', 10),
+        limit: parseInt(process.env.THROTTLE_LIMIT || '60', 10),
+      },
+    ]),
   ],
   controllers: [AppController],
-  providers: [BigQueryService, GcsService, AppService],
+  providers: [
+    BigQueryService,
+    GcsService,
+    AppService,
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
+  ],
 })
 export class AppModule {
   configure(consumer: MiddlewareConsumer) {

--- a/src/base/base.controller.ts
+++ b/src/base/base.controller.ts
@@ -7,11 +7,12 @@ import { Format } from '../common/dto/requests/get-by-location.dto';
 import { ApiSecurity, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CountHeader } from '../decorators/count-header.decorator';
 import { IsAuthenticatedGuard } from '../guards/is-authenticated.guard';
+import { DemoLocationGuard } from '../guards/demo-location.guard';
 
 @ApiTags('Base')
 @ApiSecurity('API_KEY')
 @Controller('base')
-@UseGuards(IsAuthenticatedGuard)
+@UseGuards(IsAuthenticatedGuard, DemoLocationGuard)
 export class BaseController {
 
     logger = new Logger('BaseController');

--- a/src/buildings/buildings.controller.ts
+++ b/src/buildings/buildings.controller.ts
@@ -11,11 +11,12 @@ import { Format } from '../common/dto/requests/get-by-location.dto';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { UseGuards } from '@nestjs/common';
 import { IsAuthenticatedGuard } from '../guards/is-authenticated.guard';
+import { DemoLocationGuard } from '../guards/demo-location.guard';
 
 @ApiTags('Buildings')
 @ApiSecurity('API_KEY') // Applies the API key security scheme defined in Swagger
 @Controller('buildings')
-@UseGuards(IsAuthenticatedGuard)
+@UseGuards(IsAuthenticatedGuard, DemoLocationGuard)
 export class BuildingsController {
 
   logger = new Logger('BuildingsController');

--- a/src/common/dto/requests/get-by-location.dto.ts
+++ b/src/common/dto/requests/get-by-location.dto.ts
@@ -40,6 +40,7 @@ export class GetByLocationDto {
   @Transform(({ value }) => parseFloat(value))
   @IsNumber()
   @Min(1)
+  @Max(25000, { message: 'Radius must be 25000 meters or less. For larger areas query by country or request a bulk export.' })
   radius?: number = 1000;
 
   @ApiPropertyOptional({

--- a/src/divisions/divisions.controller.ts
+++ b/src/divisions/divisions.controller.ts
@@ -7,11 +7,12 @@ import { Format } from '../common/dto/requests/get-by-location.dto';
 import { ApiSecurity, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CountHeader } from '../decorators/count-header.decorator';
 import { IsAuthenticatedGuard } from '../guards/is-authenticated.guard';
+import { DemoLocationGuard } from '../guards/demo-location.guard';
 
 @ApiTags('Divisions')
 @ApiSecurity('API_KEY')
 @Controller('divisions')
-@UseGuards(IsAuthenticatedGuard)
+@UseGuards(IsAuthenticatedGuard, DemoLocationGuard)
 export class DivisionsController {
 
     logger = new Logger('DivisionsController');

--- a/src/guards/demo-location.guard.ts
+++ b/src/guards/demo-location.guard.ts
@@ -1,0 +1,65 @@
+import { BadRequestException, CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+import { User } from '../decorators/authed-user.decorator';
+
+// Helper to calculate distance between two lat/lng points in meters
+function haversineDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const toRad = (x: number) => x * Math.PI / 180;
+  const R = 6371000; // meters
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLng / 2) * Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+const DEMO_CITIES = [
+  { city: 'New York', lat: 40.7128, lng: -74.0060 },
+  { city: 'London', lat: 51.5074, lng: -0.1278 },
+  { city: 'Paris', lat: 48.8566, lng: 2.3522 },
+  { city: 'Bondi Beach', lat: -33.8910, lng: 151.2769 },
+];
+
+const DEMO_RADIUS_METERS = 10000;
+
+/**
+ * Restricts demo accounts to locations near the demo cities. Applied at the
+ * controller level so every geographic endpoint (places, buildings, addresses,
+ * transportation, divisions, base) enforces the same cost guard, rather than
+ * relying on a per-handler decorator.
+ */
+@Injectable()
+export class DemoLocationGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request: Request = context.switchToHttp().getRequest();
+    const user = (request['user'] || request.res?.locals?.user) as User | undefined;
+
+    if (!user?.isDemoAccount) {
+      return true;
+    }
+
+    // Query params are still raw strings at the guard stage (validation/transform
+    // runs in the pipe afterwards), so parse defensively.
+    const lat = parseFloat(request.query.lat as string);
+    const lng = parseFloat(request.query.lng as string);
+
+    if (Number.isNaN(lat) || Number.isNaN(lng)) {
+      return true;
+    }
+
+    const withinRadius = DEMO_CITIES.some(
+      (city) => haversineDistance(lat, lng, city.lat, city.lng) <= DEMO_RADIUS_METERS,
+    );
+
+    if (!withinRadius) {
+      throw new BadRequestException(
+        `Demo accounts can only access locations within ${DEMO_RADIUS_METERS} meters of demo cities. Demo cities: ${DEMO_CITIES.map((city) => JSON.stringify(city)).join(', ')}. Signup for a Free account at https://overturemaps.com/`,
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/middleware/auth-api.middleware.ts
+++ b/src/middleware/auth-api.middleware.ts
@@ -11,7 +11,16 @@ import { User } from '../decorators/authed-user.decorator';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const TheAuthAPI = require('theauthapi');
 
-const DEMO_API_KEY = process.env.DEMO_API_KEY || 'DEMO-API-KEY';
+// Only enabled when explicitly configured. No literal fallback so an unset env
+// var can never leave a publicly-known demo credential valid in production.
+const DEMO_API_KEY = process.env.DEMO_API_KEY;
+
+// Avoid writing raw API keys to logs.
+function maskKey(key?: string): string {
+  if (!key) return '(none)';
+  if (key.length <= 4) return '****';
+  return `${key.slice(0, 2)}****${key.slice(-2)}`;
+}
 
 
 @Injectable()
@@ -51,52 +60,55 @@ export class AuthAPIMiddleware implements NestMiddleware {
 
     const apiKeyString = this.getAPIKeyFromHeaderOrQuery(req);
 
-    //if no api key, or user is already set, skip
-    if (!apiKeyString || req.res.locals['user']?.id) {
+    //if no api key, or user is already set, skip — the route guard decides whether anonymous is allowed
+    if (!apiKeyString || req.res.locals['user']?.userId) {
       next();
-    } else {
+      return;
+    }
 
-      try {
+    try {
 
-        // if theAuthAPI.com is integrated, check the key
-        if (this.theAuthAPI) {
+      // if theAuthAPI.com is integrated, check the key
+      if (this.theAuthAPI) {
 
-          const apiKey = await this.theAuthAPI.apiKeys.authenticateKey(apiKeyString);
-          if (apiKey) {
-            const metaData = apiKey.customMetaData as any;
-            const userObj: User = {
-              isDemoAccount: metaData.isDemoAccount || false,
-              accountId: apiKey.customAccountId,
-              userId: apiKey.customUserId,
-            };
+        const apiKey = await this.theAuthAPI.apiKeys.authenticateKey(apiKeyString);
+        if (apiKey) {
+          const metaData = apiKey.customMetaData as any;
+          const userObj: User = {
+            isDemoAccount: metaData.isDemoAccount || false,
+            accountId: apiKey.customAccountId,
+            userId: apiKey.customUserId,
+          };
 
-            //set to both req and locals for backwards compatibility
-            req['user'] = req.res.locals['user'] = userObj;
-          }
+          //set to both req and locals for backwards compatibility
+          req['user'] = req.res.locals['user'] = userObj;
           next();
           return;
         }
-      } catch (error) {
-        Logger.error('APIKeyMiddleware Error:', error, ` key: ${apiKeyString}`);
-      }
 
-      //if demo key, set user to demo user
-      if (apiKeyString === DEMO_API_KEY) {
-        const demoUser: User = {
-          isDemoAccount: true,
-          accountId: 'demo-account-id',
-          userId: 'demo-user-id'
-        };
-        req['user'] = req.res.locals['user'] = demoUser;
-        next();
+        // a key was supplied but did not authenticate — reject explicitly
+        // instead of silently continuing as anonymous.
+        res.status(401).send('Unauthorized - check the spelling of your API Key');
         return;
       }
+    } catch (error) {
+      Logger.error('APIKeyMiddleware Error:', error, ` key: ${maskKey(apiKeyString)}`);
+    }
 
-      //if we got this far and they passed a key we should tell the user their key doesn't work and to check for a spelling mistake
-      res.status(401).send('Unauthorized - check the spelling of your API Key');
-
-      next()
+    //if demo key, set user to demo user
+    if (DEMO_API_KEY && apiKeyString === DEMO_API_KEY) {
+      const demoUser: User = {
+        isDemoAccount: true,
+        accountId: 'demo-account-id',
+        userId: 'demo-user-id'
+      };
+      req['user'] = req.res.locals['user'] = demoUser;
+      next();
       return;
     }
+
+    //if we got this far and they passed a key we should tell the user their key doesn't work and to check for a spelling mistake
+    res.status(401).send('Unauthorized - check the spelling of your API Key');
+    return;
   }
 }

--- a/src/transportation/transportation.controller.ts
+++ b/src/transportation/transportation.controller.ts
@@ -7,11 +7,12 @@ import { Format } from '../common/dto/requests/get-by-location.dto';
 import { ApiSecurity, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CountHeader } from '../decorators/count-header.decorator';
 import { IsAuthenticatedGuard } from '../guards/is-authenticated.guard';
+import { DemoLocationGuard } from '../guards/demo-location.guard';
 
 @ApiTags('Transportation')
 @ApiSecurity('API_KEY')
 @Controller('transportation')
-@UseGuards(IsAuthenticatedGuard)
+@UseGuards(IsAuthenticatedGuard, DemoLocationGuard)
 export class TransportationController {
 
     logger = new Logger('TransportationController');

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -75,7 +75,7 @@ describe('AppController (e2e)', () => {
     mockBigQueryService.getAddressesNearby.mockResolvedValue(mockData.map(parseAddressRow));
 
     const response = await request(app.getHttpServer())
-      .get('/addresses?lat=37.7749&lng=-122.4194')
+      .get('/addresses?lat=40.7128&lng=-74.0060')
       .set('x-api-key', 'DEMO-API-KEY')
       .expect(200);
 
@@ -90,7 +90,7 @@ describe('AppController (e2e)', () => {
     mockBigQueryService.getBaseNearby.mockResolvedValue(mockData.map(parseBaseRow));
 
     const response = await request(app.getHttpServer())
-      .get('/base?lat=37.7749&lng=-122.4194')
+      .get('/base?lat=40.7128&lng=-74.0060')
       .set('x-api-key', 'DEMO-API-KEY')
       .expect(200);
 
@@ -120,7 +120,7 @@ describe('AppController (e2e)', () => {
     mockBigQueryService.getTransportationNearby.mockResolvedValue(mockData.map(parseTransportationRow));
 
     const response = await request(app.getHttpServer())
-      .get('/transportation?lat=37.7749&lng=-122.4194')
+      .get('/transportation?lat=40.7128&lng=-74.0060')
       .set('x-api-key', 'DEMO-API-KEY')
       .expect(200);
 
@@ -135,7 +135,7 @@ describe('AppController (e2e)', () => {
     mockBigQueryService.getDivisionsNearby.mockResolvedValue(mockData.map(parseDivisionRow));
 
     const response = await request(app.getHttpServer())
-      .get('/divisions?lat=37.7749&lng=-122.4194')
+      .get('/divisions?lat=40.7128&lng=-74.0060')
       .set('x-api-key', 'DEMO-API-KEY')
       .expect(200);
 

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -3,6 +3,7 @@
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
+  "setupFiles": ["<rootDir>/setup-e2e.ts"],
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }

--- a/test/setup-e2e.ts
+++ b/test/setup-e2e.ts
@@ -1,0 +1,6 @@
+// e2e test setup. Runs before the application module graph is imported, so the
+// auth middleware's module-level DEMO_API_KEY constant picks this up.
+//
+// Production no longer ships a hardcoded demo key (see auth-api.middleware.ts);
+// the e2e suite opts in to a known demo key explicitly here.
+process.env.DEMO_API_KEY = process.env.DEMO_API_KEY || 'DEMO-API-KEY';


### PR DESCRIPTION
Security review fixes for unauthenticated/abusive access and BigQuery cost exposure:

- Cap radius at 25000m on the base location DTO so all geographic endpoints (buildings/addresses/transportation/divisions/base) are bounded, not just /places.
- Add DemoLocationGuard and apply the 10km demo-city geo-fence to every data controller, not just /places.
- Add global per-client rate limiting via @nestjs/throttler (configurable through THROTTLE_LIMIT / THROTTLE_TTL_MS).
- Auth middleware: return explicit 401 on a key that fails to authenticate instead of silently continuing as anonymous; return after every response to avoid post-send next(); mask API keys in logs; drop the hardcoded 'DEMO-API-KEY' fallback; fix dead ?.id check.