### PR TITLE
Query caching improvements + historic endpoint-cost backfill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ USAGE_FLUSH_MAX_ROWS=500
 # Per-client rate limiting
 THROTTLE_TTL_MS=60000
 THROTTLE_LIMIT=60
+
+# App-level result cache TTL in seconds (Overture data changes ~monthly; default 24h)
+CACHE_TTL_SECONDS=86400

--- a/etl/historic-endpoint-costs-backfill.sql
+++ b/etl/historic-endpoint-costs-backfill.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- Historic endpoint cost backfill  (one-time, time-sensitive)
+-- ============================================================================
+-- Per-account attribution is NOT possible for historic jobs: the account_id /
+-- request_id labels only began with the usage-tracking deploy (2026-06-15), all
+-- API jobs ran as a single runtime service account, and query filters are bound
+-- parameters (never in the SQL text). The only historic signal is the ENDPOINT,
+-- from the "-- Overture Maps API: <endpoint>" comment each query carries.
+--
+-- This snapshots endpoint-level unit economics from INFORMATION_SCHEMA.JOBS,
+-- which only retains 180 days — so run this before the oldest data rolls off.
+--
+-- IMPORTANT — avoid double counting:
+--   Multi-statement endpoints (buildings/addresses/transportation/divisions/
+--   base, and places+buildings) run as SCRIPT jobs. The SCRIPT parent already
+--   aggregates its child statements' billed bytes AND carries the comment, while
+--   the child SELECT jobs do not carry the comment. Summing every job therefore
+--   double counts script children. We keep only top-level jobs (parent_job_id IS
+--   NULL): SCRIPT parents (aggregated) + standalone SELECTs. (Naively summing all
+--   jobs reports ~$483/180d; the correct top-level figure is ~$279.)
+
+CREATE OR REPLACE TABLE `usage.historic_endpoint_costs`
+PARTITION BY usage_date AS
+SELECT
+  DATE(creation_time)                                              AS usage_date,
+  TRIM(REGEXP_EXTRACT(query, r"-- Overture Maps API: ([^\n]+)"))   AS endpoint,
+  COUNT(*)                                                         AS jobs,
+  SUM(total_bytes_billed)                                          AS bytes_billed,
+  ROUND(SUM(total_bytes_billed) / 1e12 * 5, 6)                     AS cost_usd,
+  CAST(APPROX_QUANTILES(total_bytes_billed, 100)[OFFSET(50)] AS INT64) AS p50_bytes_billed,
+  CAST(APPROX_QUANTILES(total_bytes_billed, 100)[OFFSET(95)] AS INT64) AS p95_bytes_billed,
+  CURRENT_TIMESTAMP()                                             AS snapshot_ts
+FROM `region-us`.INFORMATION_SCHEMA.JOBS_BY_PROJECT
+WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 180 DAY)
+  AND job_type = 'QUERY'
+  AND parent_job_id IS NULL                 -- top-level only; SCRIPT parents aggregate children
+  AND query LIKE '-- Overture Maps API%'    -- only API-issued queries
+GROUP BY usage_date, endpoint;
+
+-- ----------------------------------------------------------------------------
+-- Read-back: endpoint unit economics over the snapshot window
+-- ----------------------------------------------------------------------------
+-- SELECT
+--   endpoint,
+--   SUM(jobs)                                   AS jobs,
+--   ROUND(SUM(cost_usd), 2)                     AS cost_usd,
+--   ROUND(SUM(cost_usd) / SUM(jobs), 6)         AS avg_cost_per_call,
+--   ROUND(MAX(p95_bytes_billed) / 1e9, 2)       AS worst_day_p95_gb
+-- FROM `usage.historic_endpoint_costs`
+-- GROUP BY endpoint
+-- ORDER BY cost_usd DESC;

--- a/src/addresses/addresses.service.ts
+++ b/src/addresses/addresses.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { BigQueryService } from '../bigquery/bigquery.service';
 import { CacheService } from '../cache/cache.service';
+import { buildCacheKey, CACHE_TTL_SECONDS } from '../cache/cache-key.util';
 import { GetAddressesQuery } from './dto/requests/get-addresses-query.dto';
 import { Address } from './interfaces/address.interface';
 
@@ -15,13 +16,13 @@ export class AddressesService {
 
     async getAddresses(query: GetAddressesQuery): Promise<Address[]> {
         const { lat, lng, radius, limit } = query;
-        const cacheKey = `get-addresses-${JSON.stringify(query)}`;
+        const cacheKey = buildCacheKey('get-addresses', { lat, lng, radius, limit });
 
         let results: Address[] | undefined = await this.cacheService.get<Address[]>(cacheKey);
 
         if (!results) {
             results = await this.bigQueryService.getAddressesNearby(lat, lng, radius, limit);
-            await this.cacheService.set(cacheKey, results, 3600);
+            await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         }
         return results;
     }

--- a/src/base/base.service.ts
+++ b/src/base/base.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { BigQueryService } from '../bigquery/bigquery.service';
 import { CacheService } from '../cache/cache.service';
+import { buildCacheKey, CACHE_TTL_SECONDS } from '../cache/cache-key.util';
 import { GetBaseQuery } from './dto/requests/get-base-query.dto';
 import { BaseFeature } from './interfaces/base.interface';
 
@@ -15,13 +16,13 @@ export class BaseService {
 
     async getBaseFeatures(query: GetBaseQuery): Promise<BaseFeature[]> {
         const { lat, lng, radius, limit } = query;
-        const cacheKey = `get-base-${JSON.stringify(query)}`;
+        const cacheKey = buildCacheKey('get-base', { lat, lng, radius, limit });
 
         let results: BaseFeature[] | undefined = await this.cacheService.get<BaseFeature[]>(cacheKey);
 
         if (!results) {
             results = await this.bigQueryService.getBaseNearby(lat, lng, radius, limit);
-            await this.cacheService.set(cacheKey, results, 3600);
+            await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         }
         return results;
     }

--- a/src/bigquery/bigquery.service.ts
+++ b/src/bigquery/bigquery.service.ts
@@ -183,9 +183,8 @@ export class BigQueryService {
 
     queryParts.push(`
     -- Overture Maps API: Get Places with Buildings
-    -- Step 1: Define the search area as a circular polygon around the point with a specified radius
-    DECLARE search_area_geometry GEOGRAPHY;
-    SET search_area_geometry = ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius);
+    -- Single statement (no DECLARE) so BigQuery can serve identical repeat queries
+    -- from its free results cache. The search area is inlined as ST_Buffer(...).
     `);
     params.longitude = longitude;
     params.latitude = latitude;
@@ -235,7 +234,7 @@ export class BigQueryService {
         FROM
           \`bigquery-public-data.overture_maps.building\`
         WHERE
-          ST_WITHIN(geometry, search_area_geometry)
+          ST_WITHIN(geometry, ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius))
           AND ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)
       ),
     
@@ -254,7 +253,7 @@ export class BigQueryService {
         ON
           ST_DWithin(p.geometry, b.building_geometry, @radius)
         WHERE
-          ST_WITHIN(p.geometry, search_area_geometry)
+          ST_WITHIN(p.geometry, ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius))
         `
         + (whereClauses.length > 0 ? `AND ${whereClauses.join(' AND ')}` : '') +
         `
@@ -284,7 +283,7 @@ export class BigQueryService {
       ON
         ST_WITHIN(p.geometry, b.geometry)
       WHERE
-        ST_WITHIN(p.geometry, search_area_geometry)
+        ST_WITHIN(p.geometry, ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius))
         `
         + (whereClauses.length > 0 ? `AND ${whereClauses.join(' AND ')}` : '') +
         `
@@ -417,17 +416,15 @@ export class BigQueryService {
 
     queryParts.push(
       `-- Overture Maps API: Get Buildings Nearby
-    -- Step 1: define the search area to limit the cost in step 2 taking advantage of the 'geometry' clustering
-DECLARE search_area_geometry GEOGRAPHY;
-SET search_area_geometry = ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius);
-
--- Step 2: Select buildings within the search area
+    -- Single statement (no DECLARE) so BigQuery can serve identical repeat queries
+    -- from its free results cache. ST_Buffer is inlined; the 'geometry' clustering
+    -- is still pruned and the result set is unchanged.
 SELECT
   *
  ,ST_Distance(geometry, ST_GeogPoint(@longitude, @latitude)) AS ext_distance
 FROM
   \`bigquery-public-data.overture_maps.building\` AS s
-WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
+WHERE ST_WITHIN(s.geometry, ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius)) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
 
     // Order by distance if latitude and longitude are provided
     if (latitude && longitude) {
@@ -529,17 +526,13 @@ WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_Ge
 
     queryParts.push(
       `-- Overture Maps API: Get Addresses Nearby
-    -- Step 1: define the search area
-DECLARE search_area_geometry GEOGRAPHY;
-SET search_area_geometry = ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius);
-
--- Step 2: Select addresses within the search area
+    -- Single statement (no DECLARE) so BigQuery can cache identical repeat queries.
 SELECT
   *
  ,ST_Distance(geometry, ST_GeogPoint(@longitude, @latitude)) AS ext_distance
 FROM
   \`bigquery-public-data.overture_maps.address\` AS s
-WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
+WHERE ST_WITHIN(s.geometry, ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius)) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
 
     // Order by distance if latitude and longitude are provided
     if (latitude && longitude) {
@@ -571,11 +564,7 @@ WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_Ge
 
     queryParts.push(
       `-- Overture Maps API: Get Base Features Nearby (Land Use + Land Cover)
-    -- Step 1: define the search area
-DECLARE search_area_geometry GEOGRAPHY;
-SET search_area_geometry = ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius);
-
--- Step 2: Select base features within the search area merging land_use and land_cover
+    -- Single statement (no DECLARE) so BigQuery can cache identical repeat queries.
 WITH combined_base AS (
   SELECT id, geometry, bbox, version, sources, subtype, class FROM \`bigquery-public-data.overture_maps.land_use\`
   UNION ALL
@@ -586,7 +575,7 @@ SELECT
  ,ST_Distance(geometry, ST_GeogPoint(@longitude, @latitude)) AS ext_distance
 FROM
   combined_base AS s
-WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
+WHERE ST_WITHIN(s.geometry, ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius)) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
 
     // Order by distance if latitude and longitude are provided
     if (latitude && longitude) {
@@ -618,17 +607,13 @@ WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_Ge
 
     queryParts.push(
       `-- Overture Maps API: Get Transportation Segments Nearby
-    -- Step 1: define the search area
-DECLARE search_area_geometry GEOGRAPHY;
-SET search_area_geometry = ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius);
-
--- Step 2: Select transportation segments within the search area
+    -- Single statement (no DECLARE) so BigQuery can cache identical repeat queries.
 SELECT
   *
  ,ST_Distance(geometry, ST_GeogPoint(@longitude, @latitude)) AS ext_distance
 FROM
   \`bigquery-public-data.overture_maps.segment\` AS s
-WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
+WHERE ST_WITHIN(s.geometry, ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius)) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
 
     // Order by distance if latitude and longitude are provided
     if (latitude && longitude) {
@@ -660,17 +645,13 @@ WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_Ge
 
     queryParts.push(
       `-- Overture Maps API: Get Division Areas Nearby
-    -- Step 1: define the search area
-DECLARE search_area_geometry GEOGRAPHY;
-SET search_area_geometry = ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius);
-
--- Step 2: Select division areas within the search area
+    -- Single statement (no DECLARE) so BigQuery can cache identical repeat queries.
 SELECT
   *
  ,ST_Distance(geometry, ST_GeogPoint(@longitude, @latitude)) AS ext_distance
 FROM
   \`bigquery-public-data.overture_maps.division_area\` AS s
-WHERE ST_WITHIN(s.geometry, search_area_geometry) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
+WHERE ST_WITHIN(s.geometry, ST_Buffer(ST_GeogPoint(@longitude, @latitude), @radius)) and ST_DWithin(geometry, ST_GeogPoint(@longitude, @latitude), @radius)`);
 
     // Order by distance if latitude and longitude are provided
     if (latitude && longitude) {

--- a/src/buildings/buildings.service.ts
+++ b/src/buildings/buildings.service.ts
@@ -12,6 +12,7 @@ import { ConfigService } from '@nestjs/config';
 import { CloudStorageCacheService } from '../cloudstorage-cache/cloudstorage-cache.service';
 import { GetBuildingsQuery } from './dto/requests/get-buildings-query.dto';
 import { Building } from './interfaces/building.interface';
+import { buildCacheKey } from '../cache/cache-key.util';
 
 @Injectable()
 export class BuildingsService {
@@ -27,8 +28,9 @@ export class BuildingsService {
     async getBuildings(query: GetBuildingsQuery): Promise<Building[]> {
         const {  lat, lng, radius,limit } = query;
   
-        // Check if cached results exist in File Cache
-        const cacheKey = `get-places-brands-${JSON.stringify(query)}`;
+        // Check if cached results exist in File Cache. Key on data-affecting params
+        // only (not presentation/format) so equivalent requests share one entry.
+        const cacheKey = buildCacheKey('get-buildings', { lat, lng, radius, limit });
         const cachedResult = await this.cloudStorageCache.getJSON(cacheKey);
         if (cachedResult) {
           return cachedResult;

--- a/src/cache/cache-key.util.spec.ts
+++ b/src/cache/cache-key.util.spec.ts
@@ -1,0 +1,33 @@
+import { buildCacheKey } from './cache-key.util';
+
+describe('buildCacheKey', () => {
+  it('is stable regardless of property order', () => {
+    const a = buildCacheKey('get-places', { lat: 40.7, lng: -74, radius: 1000 });
+    const b = buildCacheKey('get-places', { radius: 1000, lng: -74, lat: 40.7 });
+    expect(a).toBe(b);
+  });
+
+  it('omits undefined, null and empty values', () => {
+    const key = buildCacheKey('get-places', {
+      lat: 40.7,
+      lng: -74,
+      country: undefined,
+      brand_name: null,
+      source: '',
+    });
+    expect(key).toBe('get-places:lat=40.7&lng=-74');
+  });
+
+  it('normalises array order so equivalent category sets collide', () => {
+    const a = buildCacheKey('get-places', { categories: ['retail', 'food'] });
+    const b = buildCacheKey('get-places', { categories: ['food', 'retail'] });
+    expect(a).toBe(b);
+    expect(a).toBe('get-places:categories=food,retail');
+  });
+
+  it('produces different keys for different data params', () => {
+    const a = buildCacheKey('get-places', { lat: 40.7, lng: -74 });
+    const b = buildCacheKey('get-places', { lat: 51.5, lng: -0.1 });
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/cache/cache-key.util.ts
+++ b/src/cache/cache-key.util.ts
@@ -1,0 +1,25 @@
+// Builds a stable cache key from only the parameters that affect the underlying
+// BigQuery result. Presentation params (format, includes, enrichment_fields) and
+// post-query filters (source) are deliberately excluded by the caller so that, e.g.
+// a `json` and a `geojson` request for the same data share one cache entry.
+//
+// Keys are sorted and array values are order-normalised so equivalent queries map
+// to the same key regardless of how the client ordered them.
+export function buildCacheKey(prefix: string, parts: Record<string, unknown>): string {
+  const normalized = Object.keys(parts)
+    .filter((k) => parts[k] !== undefined && parts[k] !== null && parts[k] !== '')
+    .sort()
+    .map((k) => {
+      const value = parts[k];
+      const rendered = Array.isArray(value)
+        ? [...value].map(String).sort().join(',')
+        : String(value);
+      return `${k}=${rendered}`;
+    })
+    .join('&');
+  return `${prefix}:${normalized}`;
+}
+
+// Overture data only changes on monthly releases, so cached results can live far
+// longer than the original 1h. Configurable without a redeploy; defaults to 24h.
+export const CACHE_TTL_SECONDS = parseInt(process.env.CACHE_TTL_SECONDS || '86400', 10);

--- a/src/divisions/divisions.service.ts
+++ b/src/divisions/divisions.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { BigQueryService } from '../bigquery/bigquery.service';
 import { CacheService } from '../cache/cache.service';
+import { buildCacheKey, CACHE_TTL_SECONDS } from '../cache/cache-key.util';
 import { GetDivisionsQuery } from './dto/requests/get-divisions-query.dto';
 import { DivisionArea } from './interfaces/division.interface';
 
@@ -15,13 +16,13 @@ export class DivisionsService {
 
     async getDivisions(query: GetDivisionsQuery): Promise<DivisionArea[]> {
         const { lat, lng, radius, limit } = query;
-        const cacheKey = `get-divisions-${JSON.stringify(query)}`;
+        const cacheKey = buildCacheKey('get-divisions', { lat, lng, radius, limit });
 
         let results: DivisionArea[] | undefined = await this.cacheService.get<DivisionArea[]>(cacheKey);
 
         if (!results) {
             results = await this.bigQueryService.getDivisionsNearby(lat, lng, radius, limit);
-            await this.cacheService.set(cacheKey, results, 3600);
+            await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         }
         return results;
     }

--- a/src/places/places.service.spec.ts
+++ b/src/places/places.service.spec.ts
@@ -6,6 +6,15 @@ import { GetPlacesDto } from './dto/requests/get-places.dto';
 import { PlaceResponseDto, toPlaceDto } from './dto/responses/place-response.dto';
 import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../cache/cache.service';
+import { buildCacheKey, CACHE_TTL_SECONDS } from '../cache/cache-key.util';
+
+// Mirrors the data-affecting params the service keys on (excludes presentation params).
+const placesKey = (q: GetPlacesDto) =>
+  buildCacheKey('get-places', {
+    lat: q.lat, lng: q.lng, radius: q.radius, country: q.country,
+    min_confidence: q.min_confidence, brand_wikidata: q.brand_wikidata,
+    brand_name: q.brand_name, categories: q.categories, limit: q.limit,
+  });
 
 describe('PlacesService', () => {
   let service: PlacesService;
@@ -174,7 +183,7 @@ describe('PlacesService', () => {
 
     const result = await service.getPlaces(query);
 
-    expect(mockCacheGet).toHaveBeenCalledWith(`get-places-${JSON.stringify(query)}`);
+    expect(mockCacheGet).toHaveBeenCalledWith(placesKey(query));
     expect(mockBigQueryGetPlacesNearby).not.toHaveBeenCalled();
     expect(result).toEqual(mockPlaceResponseDto);
   });
@@ -198,7 +207,7 @@ describe('PlacesService', () => {
 
     const result = await service.getPlaces(query);
 
-    expect(mockCacheGet).toHaveBeenCalledWith(`get-places-${JSON.stringify(query)}`);
+    expect(mockCacheGet).toHaveBeenCalledWith(placesKey(query));
     expect(mockBigQueryGetPlacesNearby).toHaveBeenCalledWith(
       query.lat,
       query.lng,
@@ -211,7 +220,7 @@ describe('PlacesService', () => {
       query.limit
     );
     
-    expect(mockCacheSet).toHaveBeenCalledWith(`get-places-${JSON.stringify(query)}`, mockBigQueryGetPlacesNearbyResponse, 3600);
+    expect(mockCacheSet).toHaveBeenCalledWith(placesKey(query), mockBigQueryGetPlacesNearbyResponse, CACHE_TTL_SECONDS);
     expect(result).toEqual(mockPlaceResponseDto);
   });
 

--- a/src/places/places.service.ts
+++ b/src/places/places.service.ts
@@ -18,6 +18,7 @@ import { ValidateLatLngUser } from '../decorators/validate-lat-lng-user.decorato
 import { Place, PlaceWithBuilding } from './interfaces/place.interface';
 import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../cache/cache.service';
+import { buildCacheKey, CACHE_TTL_SECONDS } from '../cache/cache-key.util';
 import { GetPlacesWithBuildingsDto } from './dto/requests/get-places-with-buildings';
 
 @Injectable()
@@ -32,11 +33,13 @@ export class PlacesService {
     async getPlaces(query: GetPlacesDto):Promise<Place[]> {
 
         const { lat, lng, radius,  country, min_confidence, brand_wikidata,brand_name,categories,limit, source } = query;
-        const cacheKey = `get-places-${JSON.stringify(query)}`;
+        // Key on data-affecting params only. `source` is applied as a post-query
+        // filter below, so it must not split the cache.
+        const cacheKey = buildCacheKey('get-places', { lat, lng, radius, country, min_confidence, brand_wikidata, brand_name, categories, limit });
         let results: Place[] | undefined = await this.cacheService.get<Place[]>(cacheKey);
         if (!results) {
           results = await this.bigQueryService.getPlacesNearby(lat, lng, radius, brand_wikidata, brand_name, country, categories, min_confidence, limit);
-          await this.cacheService.set(cacheKey, results, 3600);
+          await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         }
         // Filter by source if provided
         if (source) {
@@ -49,12 +52,12 @@ export class PlacesService {
       async getPlacesWithNearestBuilding(query: GetPlacesWithBuildingsDto):Promise<PlaceWithBuilding[]> {
 
         const { lat, lng, radius, country, min_confidence, brand_wikidata,brand_name,categories,limit, match_nearest_building} = query;
-    
-        const cacheKey = `get-places-${JSON.stringify(query)}`;
+
+        const cacheKey = buildCacheKey('get-places-with-building', { lat, lng, radius, country, min_confidence, brand_wikidata, brand_name, categories, limit, match_nearest_building });
         let results: PlaceWithBuilding[] | undefined = await this.cacheService.get<PlaceWithBuilding[]>(cacheKey);
         if (!results) {
           results = await this.bigQueryService.getPlacesWithNearestBuilding(lat, lng, radius, brand_wikidata, brand_name, country, categories, min_confidence, limit, match_nearest_building);
-          await this.cacheService.set(cacheKey, results, 3600);
+          await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         }
         return results;
         
@@ -62,15 +65,15 @@ export class PlacesService {
 
     async getBrands(query: GetBrandsDto): Promise<BrandDto[]> {
         const { country, lat, lng, radius, categories } = query;
-  
-        const cacheKey = `get-places-brands-${JSON.stringify(query)}`;
+
+        const cacheKey = buildCacheKey('get-places-brands', { country, lat, lng, radius, categories });
         const cachedResult = await this.cacheService.get<any[]>(cacheKey);
         if (cachedResult) {
-          return cachedResult;
+          return cachedResult.map((brand: any) => new BrandDto(brand));
         }
 
         const results = await this.bigQueryService.getBrandsNearby(country, lat, lng, radius, categories);
-        await this.cacheService.set(cacheKey, results, 3600);
+        await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         return results.map((brand: any) => new BrandDto(brand));
       }
 
@@ -78,25 +81,25 @@ export class PlacesService {
         const cacheKey = `get-places-countries`;
         const cachedResult = await this.cacheService.get<any[]>(cacheKey);
         if (cachedResult) {
-          return cachedResult;
+          return cachedResult.map((country: any) => toCountryResponseDto(country));
         }
 
         const results = await this.bigQueryService.getPlaceCountsByCountry();
-        await this.cacheService.set(cacheKey, results, 3600);
+        await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         return results.map((country: any) => toCountryResponseDto(country));
     }
 
     async getCategories(query: GetCategoriesDto): Promise<CategoryResponseDto[]> {
 
-        const cacheKey = `get-places-categories-${JSON.stringify(query)}`;
+        const cacheKey = buildCacheKey('get-places-categories', { country: query.country, lat: query.lat, lng: query.lng, radius: query.radius });
         const cachedResult = await this.cacheService.get<any[]>(cacheKey);
         if (cachedResult) {
-          return cachedResult;
+          return cachedResult.map((category: any) => toCategoryResponseDto(category));
         }
 
         const results = await this.bigQueryService.getCategories(query.country, query.lat, query.lng, query.radius);
 
-        await this.cacheService.set(cacheKey, results, 3600);
+        await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         return results.map((category: any) => toCategoryResponseDto(category));
       }
 

--- a/src/transportation/transportation.service.ts
+++ b/src/transportation/transportation.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { BigQueryService } from '../bigquery/bigquery.service';
 import { CacheService } from '../cache/cache.service';
+import { buildCacheKey, CACHE_TTL_SECONDS } from '../cache/cache-key.util';
 import { GetTransportationQuery } from './dto/requests/get-transportation-query.dto';
 import { TransportationSegment } from './interfaces/transportation.interface';
 
@@ -15,13 +16,13 @@ export class TransportationService {
 
     async getTransportationSegments(query: GetTransportationQuery): Promise<TransportationSegment[]> {
         const { lat, lng, radius, limit } = query;
-        const cacheKey = `get-transportation-${JSON.stringify(query)}`;
+        const cacheKey = buildCacheKey('get-transportation', { lat, lng, radius, limit });
 
         let results: TransportationSegment[] | undefined = await this.cacheService.get<TransportationSegment[]>(cacheKey);
 
         if (!results) {
             results = await this.bigQueryService.getTransportationNearby(lat, lng, radius, limit);
-            await this.cacheService.set(cacheKey, results, 3600);
+            await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
         }
         return results;
     }


### PR DESCRIPTION
Follow-up to #15. These two commits were pushed after #15 merged, so they need their own PR.

## 1. Caching improvements (`a28945f`)

The cost review found the script-based endpoints had a **0% BigQuery cache-hit rate** — multi-statement `DECLARE/SET` scripts are never eligible for BigQuery's free results cache, while single-statement SELECTs (places) already saw 32% hits. Buildings alone is 73% of spend and cached nothing.

- **A. Single-statement rewrites** of buildings/addresses/transportation/divisions/base/places-with-buildings — inline `ST_Buffer(...)` instead of a declared `search_area_geometry`. Validated against live BigQuery: **identical row count, identical billed bytes**, and the repeat query now serves from cache at **0 bytes / ~150ms** (was ~2.1s).
- **B. Longer TTL** — app cache raised from 1h to a configurable 24h (`CACHE_TTL_SECONDS`); Overture data only changes ~monthly.
- **C. Normalized cache keys** (`buildCacheKey`) — key on data-affecting params only, excluding presentation params (format/includes/enrichment_fields) and the post-query `source` filter, so equivalent requests share one entry.
- **D. Fixed buildings cache key** (was mislabeled `get-places-brands-`).
- Bonus: fixed a latent bug where brands/categories/countries returned raw cached objects instead of mapped DTOs on a cache hit.

## 2. Historic endpoint-cost backfill (`5558044`)

One-time snapshot of 180 days of endpoint-level BigQuery cost from `INFORMATION_SCHEMA.JOBS` into `usage.historic_endpoint_costs`. Per-account attribution is impossible for historic jobs (labels/account ids were never recorded), so this captures endpoint-level unit economics. Counts top-level jobs only (`parent_job_id IS NULL`) to avoid double-counting SCRIPT children. Time-sensitive: INFORMATION_SCHEMA retains only 180 days.

## Testing
- Unit: 45 pass (new tests for `buildCacheKey`).
- E2E: app suite passes; live suite skips without a key.
- `npm run build` clean.
- Rewrite validated empirically: same results, same cost-per-miss, now cacheable.

## Deploy note
Cross-instance cache hits require a shared backend (Redis via `redisUrl`, or the GCS cache) configured in prod — with in-memory only, each Cloud Run instance caches independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)