### PR TITLE
feat: Wikidata brand enrichment — logos, websites, industry, parent org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ CACHE_TTL_SECONDS=86400
 # Build/refresh the artifact after each monthly Overture release: npm run etl:divisions-search-index
 DIVISIONS_SEARCH_INDEX_ENABLED=true
 DIVISIONS_SEARCH_INDEX_OBJECT=search-indexes/divisions-v1.ndjson.gz
+
+# Wikidata brand enrichment (in-memory, loaded from GCS; ext_ brand fields are omitted when absent)
+# Build/refresh the artifact monthly: npm run etl:brands-enrichment
+BRANDS_ENRICHMENT_ENABLED=true
+BRANDS_ENRICHMENT_OBJECT=enrichment/brands-v1.ndjson.gz

--- a/.github/workflows/brands-enrichment.yml
+++ b/.github/workflows/brands-enrichment.yml
@@ -1,0 +1,40 @@
+name: Rebuild Brands Enrichment Artifact
+
+# Rebuilds the Wikidata brand-enrichment artifact in GCS (see
+# etl/build-brands-enrichment.ts). Runs monthly after Overture's mid-month
+# release so newly added brand QIDs are picked up; re-runs are idempotent and
+# cheap (~3k-row BigQuery scan + ~21 SPARQL queries). The API refreshes its
+# in-memory copy within a day of the artifact changing.
+
+on:
+  workflow_dispatch: # Allows manual trigger from GitHub UI
+  schedule:
+    - cron: '0 3 25 * *' # 25th of each month, 03:00 UTC
+
+jobs:
+  build-artifact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: npm install
+        run: npm ci
+
+      - name: create credentials file
+        run: |
+          echo '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}' > gcp-credentials.json
+
+      - name: Build and upload brands enrichment artifact
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ./gcp-credentials.json
+          BIGQUERY_PROJECT_ID: ${{ secrets.BIGQUERY_PROJECT_ID }}
+          GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
+        run: npm run etl:brands-enrichment

--- a/docs/demographics-enrichment-plan.md
+++ b/docs/demographics-enrichment-plan.md
@@ -1,0 +1,94 @@
+# Demographics Enrichment Plan — BigQuery Public Data
+
+**Status: PLAN ONLY — nothing implemented yet.**
+Goal: enrich Overture places/divisions/locations with demographic data, additively (no breaking changes), using datasets already in BigQuery's `US` multi-region so joins against `bigquery-public-data.overture_maps.*` need no ETL for v1.
+
+## Verified data sources (checked 2026-07-08 with the repo service account)
+
+| Dataset | Coverage | Granularity | Tables (verified) | Notes |
+|---|---|---|---|---|
+| `bigquery-public-data.census_bureau_acs` | **US only** | block group → tract → county → CBSA → state → ZIP | 278 tables, e.g. `blockgroup_YYYY_5yr`, `censustract_YYYY_5yr`, `county_YYYY_1yr`, `zcta_...` | The rich one: median income, age bands, households, housing, commute, education. **Vintage check needed** — newest visible vintages cluster around 2018–2021; pick latest per geo level in the validation spike. |
+| `bigquery-public-data.geo_us_boundaries` | US | states, counties, ZIP codes, CBSAs, urban areas | 16 tables incl. `counties`, `states`, `zip_codes`, `cbsa` | Geometry for point→geo_id joins at coarse levels. Tract/blockgroup geometries live in the separate `geo_census_tracts` / `geo_census_blockgroups` datasets (per-state tables) — confirm in spike. |
+| `bigquery-public-data.worldpop.population_grid_1km` | **Global** | 1km grid cells | 1 table: `population_grid_1km` | `geo_id`, `population`, `geog` (GEOGRAPHY), `alpha_3_code`, `last_updated`. Only truly global small-area population source in BQ public data. Huge table — needs an optimised copy (see cost section). |
+| `bigquery-public-data.census_bureau_international` | ~200+ countries | **country-level only** | 8 tables: `midyear_population`, `midyear_population_age_sex`, `birth_death_growth_rates`, `mortality_life_expectancy`, `age_specific_fertility_rates`, `country_names_area`, ... | US Census International Database. National population, growth, life expectancy, fertility, age pyramids. |
+
+### What ISN'T in BigQuery public data (answer to "other countries?")
+
+Small-area census data for countries other than the US is **not** in `bigquery-public-data`: no Eurostat/UK ONS/StatCan/ABS equivalents of ACS. The international story is therefore two-tier:
+
+1. **Global 1km population density** via WorldPop (any lat/lng on Earth), and
+2. **Country-level indicators** via `census_bureau_international` (plus `world_bank_health_population` / `world_bank_wdi` if we want GDP-adjacent indicators later).
+
+Optional future path: CARTO's Data Observatory publishes some free international layers (e.g. Spatial Features grids with WorldPop + POI density) through BigQuery, but access runs through a CARTO account rather than `bigquery-public-data`, so it's out of scope for v1. Direct ETL of Eurostat NUTS3 / UK ONS output-area data into our own dataset is the long-term option if EU/UK customers ask — flag demand first.
+
+## Product shape (all additive)
+
+### Phase 1 — `GET /demographics` (new endpoint, global)
+
+`?lat&lng&radius` (same conventions as every other endpoint: `GetByLocationDto`, demo-city guard, count header, json/geojson).
+
+Response sketch (follows `api-design.md`: close to source schema, `ext_` for derived):
+
+```json
+{
+  "location": { "lat": 40.7128, "lng": -74.0060, "radius": 1000 },
+  "population": {
+    "total": 48213,
+    "density_per_km2": 15349,
+    "source": "worldpop",
+    "year": 2020
+  },
+  "country": {
+    "country": "US",
+    "midyear_population": 341000000,
+    "life_expectancy": 79.2,
+    "growth_rate": 0.5,
+    "source": "census_bureau_international",
+    "year": 2026
+  },
+  "us_census": null
+}
+```
+
+`population` = sum/area-weighted WorldPop cells intersecting the radius. `country` = IDB lookup via the containing Overture division (we already have country resolution). `us_census` populated in Phase 2 for US points, `null` elsewhere — additive when it arrives.
+
+### Phase 2 — US deep-dive (`us_census` block)
+
+Point → containing tract/blockgroup (geometry datasets) → join latest ACS 5yr vintage by `geo_id`. Curated stable field set rather than all 250+ ACS columns: `median_income`, `median_age`, `total_pop`, `households`, `median_rent`, `owner_occupied_housing_units`, `pop_density`, education split, commute time. Keep our field names identical to ACS column names where possible so the docs can link to Census definitions.
+
+### Phase 3 — enrich existing endpoints
+
+- `GET /divisions/{id}`: optional `include=ext_demographics` — aggregate WorldPop over the division geometry (population, density); for US divisions add ACS county/state rollups. Uses the division polygon we already fetch.
+- `GET /places`: `enrichment_fields=demographics` via the **existing enrichment adapter** (`PlaceEnrichmentDto`, `ENRICHMENT_BQ_*` pattern) — per-place tract demographics keyed by GERS ID from a precomputed table, so it's a batched key lookup, not a per-request spatial join.
+
+## Cost & performance design (the part that decides feasibility)
+
+1. **WorldPop is the risk.** The public table is global 1km (~hundreds of GB scanned if queried naively). Mitigation, in line with the existing `SOURCE_DATASET` comment ("replace with your own optimised dataset"): one-time copy into `overture-maps-api.optimised.worldpop_1km` **clustered by `geog`** — clustering turns radius queries into small scans (same trick as the existing geometry-clustered queries that bill ~0 GB). Annual refresh at most; add to the drift monitor.
+2. **ACS tables are tiny** (dimension tables keyed by `geo_id`) — negligible cost. The spatial step (point → tract) hits tract geometry tables; if per-state tables are awkward, materialise a single national tract-geometry table, also geo-clustered, in the optimised dataset.
+3. **IDB country tables are tiny** — free-tier noise. Cache country lookups in-process (static per release, ~200 rows).
+4. **Caching:** all three sources update at most annually → the existing cache layer with a long TTL (consider a per-route TTL override; current default 24h is fine to start).
+5. **Precompute for places enrichment** (Phase 3): scheduled job joins all US places → tract → curated ACS fields into an enrichment table once per ACS release, keyed by GERS ID. Serving cost is then a keyed lookup.
+
+## Non-goals / guardrails
+
+- No breaking changes; every addition is a new endpoint, new optional param, or new nullable response block.
+- No per-request scans of unclustered global tables — optimised copies first.
+- Don't promise sub-tract accuracy outside the US; the docs must state granularity per country honestly (WorldPop is modelled data).
+- Licensing: WorldPop is CC BY 4.0, Census/ACS/IDB are public domain — attribution goes in the docs page and the `source` fields, consistent with how we surface Overture `sources[].license`.
+
+## Phased delivery
+
+| Phase | Scope | Effort guess |
+|---|---|---|
+| 0. Validation spike | Confirm latest ACS vintages + tract/blockgroup geometry datasets; WorldPop `last_updated` + dry-run costs before/after clustering; sample the exact field list | small |
+| 1. `/demographics` endpoint | WorldPop radius population + IDB country block; optimised WorldPop copy; demo guard; docs | medium |
+| 2. `us_census` block | tract/blockgroup ACS join, curated fields, national tract geometry table | medium |
+| 3. Enrichment hooks | `ext_demographics` on divisions; `enrichment_fields=demographics` on places (precomputed table) | medium |
+| 4. Ops + launch | add datasets to `check-bq-schema-drift` TABLES (needs multi-dataset support — minor refactor); pricing/tier gating via key metadata (same mechanism as `/buildings`); blog post + Igal-style customer notes | small |
+
+## Open questions (to resolve in Phase 0)
+
+1. Latest ACS vintage actually present per geo level (public dataset may lag Census releases by years — affects marketing claims).
+2. Tract/blockgroup geometry source: `geo_census_tracts` per-state tables vs TIGER/Line ETL of our own.
+3. Whether `/demographics` is a paid-tier endpoint from day one (like `/buildings`) or free with tight radius caps.
+4. Population-weighted vs area-weighted apportionment for radius queries that clip WorldPop cells (recommend simple area-weighting v1, documented).

--- a/docs/gtfs-integration-investigation.md
+++ b/docs/gtfs-integration-investigation.md
@@ -1,0 +1,82 @@
+# GTFS Integration — Investigation
+
+**Status: INVESTIGATION ONLY — nothing implemented.**
+Question: can we join open transit data (GTFS) with Overture data to ship customer-facing transit features, and what would it take?
+
+## Source assessment: the Mobility Database (verified 2026-07-08)
+
+Analysed the live catalog (`https://files.mobilitydatabase.org/feeds_v2.csv`, 6,342 rows):
+
+| Metric | Value |
+|---|---|
+| Active GTFS schedule feeds | **2,722** (plus 1,707 active GTFS-Realtime; 941 deprecated / 697 inactive excluded) |
+| Countries covered | **87** |
+| Top countries (active GTFS) | US 918, JP 539, FR 484, CA 136, ES 118, IT 88, SE 60, DE 39, GB 38, PL 37, AU 30, PT 26 |
+| Feeds with a **stable mirrored download URL** (`urls.latest` on files.mobilitydatabase.org) | **2,623 / 2,740 (96%)** |
+| Feeds with a bounding box in the catalog | 2,585 / 2,740 (94%) |
+| Feeds with a licence URL | **1,534 / 2,740 (56%)** ⚠️ |
+
+Key operational facts:
+
+- MobilityData re-checks every producer URL **daily at midnight UTC** and mirrors new versions — so we ETL from their stable mirror, not from 2,700 flaky agency URLs. This removes the classic GTFS-aggregation pain.
+- The catalog CSV is public, no auth. Their **API** (feed metadata, latest-dataset hashes for incremental sync) needs a free account + refresh token.
+- The catalog itself is commercially usable (their FAQ/terms) — but the catalog's licence is **not** the feeds' licences (see risks).
+- Note: DE/GB look under-represented as raw counts because they publish **national aggregate feeds** (one feed = whole country via their National Access Points) — coverage is better than counts suggest.
+
+### What's already in BigQuery public (spoiler: not much)
+
+Only stale city one-offs: `san_francisco_transit_muni`, `new_york_subway`, citibike/bikeshare tables. Nothing global, nothing maintained. **We'd be building our own transit dataset in BigQuery — which is also the moat.** Nobody else offers "Overture places + transit proximity" as one API.
+
+## Data model (v1)
+
+Parse only the small, high-value GTFS files; skip the giant ones initially:
+
+| GTFS file | Keep? | Notes |
+|---|---|---|
+| `stops.txt` | ✅ core | id, name, lat/lng, location_type, wheelchair_boarding, parent_station. Global estimate: **~3–6M stops** across active feeds — small for BigQuery. |
+| `routes.txt` | ✅ core | route type (bus/rail/metro/tram/ferry), short/long name, agency. ~100k rows. |
+| `agency.txt` | ✅ core | operator names, tz. |
+| `stop_times.txt` + `calendar*.txt` | ⚠️ aggregate only | Hundreds of GB globally as raw rows. v1: reduce at ETL time to per-stop **service metrics** (routes serving the stop, avg weekday departures, first/last departure) and discard the raw rows. Raw schedules/routing = explicit non-goal. |
+| `shapes.txt` | ❌ v1 | Route geometries — nice later for map overlay; big and low query value initially. |
+| GTFS-Realtime | ❌ v1 | Different infra (streaming); revisit if customers ask for live arrivals. |
+
+Target: `overture-maps-api.transit.{feeds, agencies, routes, stops, stop_route_summary}` with `stops` **clustered by a GEOGRAPHY point column** — same trick as everything else, so radius queries bill ~0 GB.
+
+## ETL design
+
+Weekly Cloud Run job (GitHub Actions can't comfortably hold ~15–30GB of zips):
+
+1. Pull catalog CSV → active GTFS feeds with a mirrored `urls.latest`.
+2. Incremental: compare Mobility Database API's latest-dataset hash per feed vs our last-loaded hash; download only changed feeds (typically a few hundred/week, not 2,700).
+3. Per feed: stream-unzip, parse the 4 small files + aggregate stop_times → load staging → swap into BigQuery (per-feed partitions keyed by feed id, so one bad feed never poisons the table).
+4. Data quality gate: MobilityData publishes Canonical GTFS Validator reports per feed — skip feeds with fatal validation errors, record why.
+5. Provenance columns on every row: `feed_id`, `provider`, `feed_licence_url`, `fetched_at` — mirrors how we surface Overture `sources[].license`.
+
+Dedupe caveat: overlapping feeds exist (agency feed + regional aggregate + national aggregate → same physical stop 2–3×). v1 mitigation: prefer `is_official` feeds and de-prioritise aggregates where an official feed covers the same bbox; accept imperfection, document it.
+
+## API surface (all additive, consistent with existing conventions)
+
+1. **`GET /transit/stops?lat&lng&radius`** — stops nearby with name, modes, operators, wheelchair flag, `ext_distance`, per-stop service summary. Same DTO/guard/cache/format patterns as every other endpoint.
+2. **`ext_nearest_transit` on `/places`** (opt-in via `includes` or `enrichment_fields`) — nearest stop + distance + modes per place. Precomputed monthly into an enrichment table keyed by GERS ID (places × geo-clustered stops join), so serving is a key lookup — the enrichment adapter already supports exactly this.
+3. **`/divisions/{id}` transit summary** (later) — stop count / modes / operators within a division. Cheap once stops are geo-clustered.
+4. **Site-selection composite** (later, premium): places + demographics + transit proximity in one call — the differentiated product this all builds towards.
+
+## Risks & open questions
+
+1. **Licensing is the real risk.** 44% of active feeds list no licence URL, and the rest are heterogeneous (CC-BY, ODbL, custom agency terms; some prohibit redistribution without attribution, a few require agreements). Mitigation: carry per-feed licence in responses, publish an attribution page, and consider a conservative launch set (feeds with clear open licences — still likely 1,500+ feeds incl. all the big NAP countries). Needs a proper pass in the pilot; worth a quick legal sanity check before GA.
+2. **Feed quality variance** — validator-gated ingest (above) handles the worst; expect long-tail weirdness (stops at 0,0 etc.); add sanity filters (stop within feed bbox).
+3. **Dedupe across overlapping feeds** — accepted v1 imperfection, see above.
+4. **Freshness claims** — weekly ETL on daily-checked mirrors ⇒ "stops updated within ~8 days"; fine for schedule-level data, must not be marketed as realtime.
+5. **stop_times aggregation cost** — the one heavy compute step (national feeds are GBs). Prototype with `stop_times` streaming aggregation on 3 exemplar feeds (one small agency, one French NAP national, one Japanese aggregate) before committing to per-stop departure metrics in v1; drop to "routes-per-stop" only if too heavy.
+6. Does GBFS (bikeshare docks — realtime-ish station info, MIT-licensed catalog) ride along for near-free later? Probably, same pipeline shape.
+
+## Suggested path
+
+| Phase | Scope |
+|---|---|
+| 0. Pilot (1–2 weeks) | ETL prototype on ~10 feeds across US/FR/JP/AU incl. one national aggregate; validate parse + stop_times aggregation cost; licence audit of top-50 feeds by coverage |
+| 1. `/transit/stops` | Full ETL (validator-gated, licence-tagged), geo-clustered stops table, endpoint + docs + blog |
+| 2. Places enrichment | Precomputed `ext_nearest_transit` via enrichment adapter |
+| 3. Divisions summary + GBFS + shapes | Demand-driven |
+
+**Recommendation:** worth doing — the source is healthier than expected (96% stable mirrored URLs, daily upstream checks, validator reports for free), volumes are BigQuery-trivial once stop_times is aggregated at ETL time, and it composes with what we shipped this week (taxonomy filtering + demographics later = site-selection API). Licensing diligence is the gate: do the Phase 0 licence audit before promising customers anything.

--- a/docs/wikidata-brand-enrichment-investigation.md
+++ b/docs/wikidata-brand-enrichment-investigation.md
@@ -1,0 +1,59 @@
+# Wikidata Brand Enrichment — Investigation
+
+**Status: INVESTIGATION ONLY — nothing implemented.**
+Premise: every branded Overture place already carries `brand.wikidata` (a QID). Joining Wikidata turns that dangling ID into logos, websites, corporate hierarchy and industry — high perceived value, and the key numbers make it almost free to build.
+
+## Verified findings (2026-07-08, service account + live SPARQL)
+
+### Overture side
+
+| Metric | Value |
+|---|---|
+| Total places | 75.6M |
+| Places with a `brand.wikidata` QID | **1,551,383** |
+| **Distinct brand QIDs** | **3,019** ← the number that matters |
+| Top QID brands | ダイドー (76k places), Wildberries (55k), Western Union (40k), サントリー (36k), Amazon Locker (33k)... noticeable JP skew |
+
+3,019 distinct entities means **no dumps, no big ETL** — the entire enrichment dataset is a ~3k-row table refreshed monthly. (Caveat: `COUNTIF(brand IS NOT NULL)` returns ~60M but that's a struct artifact; 1.55M places with QIDs is the real reach, ~2% of places — but they're exactly the chains customers ask about.)
+
+### Wikidata access paths
+
+1. **SPARQL (WDQS)** — verified live: batched `VALUES` queries return per QID: label, **logo** (P154, as a Commons `Special:FilePath` URL — hotlinkable and resizable with `?width=200`), **official website** (P856), **parent org** (P749) / owner (P127), **industry** (P452), **stock ticker** (P249), plus available if wanted: social handles (P2002/P2003/P2013), founded (P571), HQ (P159). 3,019 QIDs ≈ ~30 batched queries — minutes, well inside rate limits (set a proper User-Agent).
+2. **`bigquery-public-data.wikipedia.wikidata`** — 90.7M rows / 1.7TB, **actively maintained (last modified yesterday)**. Useful as an in-warehouse supplement for multilingual labels/descriptions (en/ja/es/fr/de — the JA labels matter given the brand skew) and `instance_of`/`industry`. But it's a trimmed projection: **no logo/website/parent/ticker columns**, so SPARQL remains the primary source.
+3. Per-entity REST (`Special:EntityData/{QID}.json`) — fallback if WDQS misbehaves.
+
+### Licensing — the good news story
+
+Wikidata data is **CC0**. No attribution requirement, no share-alike, fully commercial-safe — the cleanest licence of any dataset we've looked at. One nuance: **logo image files** live on Wikimedia Commons with per-file licences (most corporate logos are `PD-textlogo`, but trademark law still applies to *use*). We serve the logo **URL**, we don't rehost; docs should state that trademark-compliant usage is the customer's responsibility. Standard practice across the industry.
+
+## Proposed architecture
+
+**ETL (monthly, GitHub Actions — this one's small enough):**
+1. One cheap BigQuery query → distinct QIDs from `place.brand.wikidata` (also catches new brands as Overture adds them).
+2. Batched SPARQL → fields above; optional join to `wikipedia.wikidata` for ja/es/fr/de labels + descriptions.
+3. Sanity gates (Wikidata is world-editable): logo URL must be `commons.wikimedia.org`, website must be http(s), field-level diff vs previous snapshot with a review threshold — a vandalised month must be rollback-able. Keep dated snapshots in GCS.
+4. Output: `brands.ndjson.gz` artifact in GCS (~3k rows) + a small BigQuery table for warehouse joins.
+
+**Serving — the elegant part:** 3,019 rows fits in process memory. Load the artifact at startup exactly like the divisions search index (`GcsService`, daily staleness check, `isReady()` fallback). Enrichment is then a zero-latency, zero-BigQuery-cost in-memory lookup by QID at response time.
+
+**API surface (all additive):**
+1. `/places/brands` — add `ext_logo_url`, `ext_website`, `ext_industry`, `ext_parent`, `ext_ticker` per brand. Instant visual upgrade for anyone building brand pickers.
+2. `/places` — opt-in `enrichment_fields=brand` (or `includes=ext_brand`) decorating each branded place from the in-memory table. Note: this path doesn't need the BQ enrichment adapter since it's QID-keyed, not GERS-keyed.
+3. Later, if pull exists: `GET /brands/{qid}` detail endpoint (brand metadata + place counts by country — the count query we already run for `/places/brands`).
+
+## Risks / caveats
+
+- **Reach is 3,019 brands, not all brands** — plenty of Overture brand structs have names but no QID. Honest docs: enrichment applies where Overture ↔ Wikidata linkage exists. (Upstream contribution angle: missing QIDs are fixable in Overture/Wikidata — good community optics.)
+- **Fill-rate unknown until we run it** — not every QID has a logo/website. Phase 0 measures this; guess: logos ~70%+, websites ~85%+ for chain brands.
+- **Vandalism/drift** — mitigated by snapshot + diff gates above; monthly cadence limits exposure.
+- **WDQS reliability** — occasional brownouts; ETL retries + last-good-snapshot fallback make this a non-event.
+
+## Suggested path
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 0. Fill-rate spike | Run the full 3,019-QID SPARQL extract once, measure logo/website/industry/parent/ticker coverage, eyeball top-100 brands for quality | ~half a day |
+| 1. ETL + `/places/brands` ext fields | Monthly workflow, GCS artifact, in-memory service, response fields, docs | small |
+| 2. `/places` brand enrichment + blog | `enrichment_fields=brand`, attribution/trademark note in docs, launch post | small |
+
+**Recommendation:** do it — this is the best effort-to-value ratio of the three datasets investigated (demographics, GTFS, Wikidata). CC0 licence, 3k-row scale, reuses two patterns we already have (GCS-artifact ETL + in-memory index), and it makes the API visibly richer in demos: logos next to place results sell themselves. Sensible sequencing: Wikidata first (days), GTFS pilot second (weeks), demographics when validated.

--- a/etl/build-brands-enrichment.ts
+++ b/etl/build-brands-enrichment.ts
@@ -1,0 +1,149 @@
+/**
+ * Builds the Wikidata brand-enrichment artifact and uploads it to GCS.
+ *
+ * Extracts every distinct `brand.wikidata` QID from Overture places (~3k),
+ * resolves each against Wikidata via batched SPARQL (label, logo, website,
+ * industry, parent org — all CC0), applies sanity gates, and writes gzipped
+ * NDJSON that the API's BrandsEnrichmentService loads into memory at startup.
+ *
+ * Run monthly (or via the brands-enrichment workflow):
+ *   npm run etl:brands-enrichment
+ *
+ * Requires .env: BIGQUERY_PROJECT_ID, GCS_BUCKET_NAME and (locally)
+ * GOOGLE_APPLICATION_CREDENTIALS. Override the object path with
+ * BRANDS_ENRICHMENT_OBJECT (default: enrichment/brands-v1.ndjson.gz).
+ */
+import 'dotenv/config';
+import { BigQuery } from '@google-cloud/bigquery';
+import { Storage } from '@google-cloud/storage';
+import { gzipSync } from 'zlib';
+import { writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const OBJECT_NAME = process.env.BRANDS_ENRICHMENT_OBJECT || 'enrichment/brands-v1.ndjson.gz';
+const SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
+const USER_AGENT = 'OvertureMapsAPI-brand-enrichment/1.0 (https://overturemapsapi.com; aden@thatapicompany.com)';
+const BATCH_SIZE = 150;
+// Abort (keeping the previous artifact) if Wikidata resolves suspiciously few
+// entities — protects against partial outages producing a hollow artifact.
+const MIN_RESOLVED_RATIO = 0.9;
+
+const QID_QUERY = `
+SELECT brand.wikidata AS qid
+FROM \`bigquery-public-data.overture_maps.place\`
+WHERE brand.wikidata IS NOT NULL AND REGEXP_CONTAINS(brand.wikidata, '^Q[0-9]+$')
+GROUP BY 1`;
+
+interface BrandRow {
+  qid: string;
+  label?: string;
+  logo_url?: string;
+  website?: string;
+  industry?: string;
+  parent?: string;
+}
+
+const sparqlBatch = async (qids: string[]): Promise<BrandRow[]> => {
+  const values = qids.map((q) => `wd:${q}`).join(' ');
+  const query = `SELECT ?qid (SAMPLE(?labelS) AS ?label) (SAMPLE(?logoS) AS ?logo) (SAMPLE(?webS) AS ?website)
+ (SAMPLE(?indS) AS ?industry) (SAMPLE(?parentS) AS ?parent) WHERE {
+ VALUES ?qid { ${values} }
+ OPTIONAL { ?qid rdfs:label ?labelS FILTER(LANG(?labelS)="en") }
+ OPTIONAL { ?qid wdt:P154 ?logoS }
+ OPTIONAL { ?qid wdt:P856 ?webS }
+ OPTIONAL { ?qid wdt:P452 ?i. ?i rdfs:label ?indS FILTER(LANG(?indS)="en") }
+ OPTIONAL { ?qid wdt:P749 ?p. ?p rdfs:label ?parentS FILTER(LANG(?parentS)="en") }
+} GROUP BY ?qid`;
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const res = await fetch(SPARQL_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/sparql-results+json',
+        'User-Agent': USER_AGENT,
+      },
+      body: 'query=' + encodeURIComponent(query),
+    });
+    if (res.ok) {
+      const data: any = await res.json();
+      return data.results.bindings.map((b: any) => ({
+        qid: b.qid.value.split('/').pop(),
+        label: b.label?.value,
+        logo_url: b.logo?.value,
+        website: b.website?.value,
+        industry: b.industry?.value,
+        parent: b.parent?.value,
+      }));
+    }
+    console.warn(`SPARQL batch failed (HTTP ${res.status}), attempt ${attempt}/3`);
+    await new Promise((r) => setTimeout(r, 2000 * attempt));
+  }
+  throw new Error('SPARQL batch failed after 3 attempts');
+};
+
+// Wikidata is world-editable: only accept values in expected shapes so a
+// vandalised statement can't inject arbitrary URLs into API responses.
+const sanitise = (row: BrandRow): BrandRow => ({
+  qid: row.qid,
+  label: row.label,
+  logo_url: row.logo_url && /^https?:\/\/commons\.wikimedia\.org\//.test(row.logo_url) ? row.logo_url : undefined,
+  website: row.website && /^https?:\/\//.test(row.website) && row.website.length < 500 ? row.website : undefined,
+  industry: row.industry && row.industry.length < 200 ? row.industry : undefined,
+  parent: row.parent && row.parent.length < 200 ? row.parent : undefined,
+});
+
+async function main() {
+  const projectId = process.env.BIGQUERY_PROJECT_ID;
+  const bucketName = process.env.GCS_BUCKET_NAME;
+  if (!projectId || !bucketName) {
+    throw new Error('BIGQUERY_PROJECT_ID and GCS_BUCKET_NAME must be set');
+  }
+
+  const bigquery = new BigQuery({ projectId });
+  console.log('Extracting distinct brand QIDs from Overture places...');
+  const [qidRows] = await bigquery.query({ query: QID_QUERY, location: 'US' });
+  const qids: string[] = qidRows.map((r: any) => r.qid);
+  console.log(`Found ${qids.length} distinct QIDs. Resolving via Wikidata SPARQL...`);
+
+  const resolved: BrandRow[] = [];
+  for (let i = 0; i < qids.length; i += BATCH_SIZE) {
+    const rows = await sparqlBatch(qids.slice(i, i + BATCH_SIZE));
+    resolved.push(...rows.map(sanitise));
+    console.log(`  batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(qids.length / BATCH_SIZE)} (${resolved.length} entities)`);
+    await new Promise((r) => setTimeout(r, 300));
+  }
+
+  if (resolved.length < qids.length * MIN_RESOLVED_RATIO) {
+    throw new Error(`Only ${resolved.length}/${qids.length} QIDs resolved — aborting without uploading (previous artifact stays live)`);
+  }
+
+  const stats = (k: keyof BrandRow) => `${((100 * resolved.filter((r) => r[k]).length) / resolved.length).toFixed(1)}%`;
+  console.log(`Resolved ${resolved.length}/${qids.length}. Fill rates: label ${stats('label')}, logo ${stats('logo_url')}, website ${stats('website')}, industry ${stats('industry')}, parent ${stats('parent')}`);
+
+  const generatedAt = new Date().toISOString();
+  const ndjson = resolved.map((r) => JSON.stringify({ ...r, updated_at: generatedAt })).join('\n');
+  const compressed = gzipSync(Buffer.from(ndjson, 'utf8'), { level: 9 });
+
+  const localPath = join(tmpdir(), 'brands-enrichment.ndjson.gz');
+  writeFileSync(localPath, compressed);
+  console.log(`Artifact: ${(compressed.length / 1024).toFixed(0)} KB gzipped (saved to ${localPath}). Uploading to gs://${bucketName}/${OBJECT_NAME} ...`);
+
+  const storage = new Storage({ projectId });
+  try {
+    // Keep a dated snapshot alongside the live object so a bad month can be rolled back.
+    await storage.bucket(bucketName).file(`${OBJECT_NAME}.${generatedAt.slice(0, 10)}`).save(compressed, { contentType: 'application/gzip' });
+    await storage.bucket(bucketName).file(OBJECT_NAME).save(compressed, { contentType: 'application/gzip', resumable: false });
+  } catch (error: any) {
+    console.error(`Upload failed (${error.message ?? error}). Upload the local artifact manually with:`);
+    console.error(`  gsutil cp ${localPath} gs://${bucketName}/${OBJECT_NAME}`);
+    process.exit(1);
+  }
+  console.log('Done. The API picks the new artifact up on its next daily refresh check, or on restart.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:live": "bash -c 'if [ -f .env.test ]; then export $(grep -v \"^#\" .env.test | xargs); fi; export DEMO_API_KEY=$TEST_API_KEY; NODE_ENV=test npx jest --config ./test/jest-e2e.json test/post-release-live.e2e-spec.ts'",
     "test:post-release-live": "bash -c 'export TEST_API_KEY=$TEST_API_KEY; npx jest --config ./test/jest-e2e.json test/post-release-live.e2e-spec.ts'",
     "etl:divisions-search-index": "ts-node etl/build-divisions-search-index.ts",
-    "etl:check-bq-schema-drift": "ts-node etl/check-bq-schema-drift.ts"
+    "etl:check-bq-schema-drift": "ts-node etl/check-bq-schema-drift.ts",
+    "etl:brands-enrichment": "ts-node etl/build-brands-enrichment.ts"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^7.9.1",

--- a/src/places/brands-enrichment.service.spec.ts
+++ b/src/places/brands-enrichment.service.spec.ts
@@ -1,0 +1,42 @@
+import { BrandsEnrichmentService } from './brands-enrichment.service';
+
+describe('BrandsEnrichmentService', () => {
+  const ndjson = [
+    JSON.stringify({ qid: 'Q37158', label: 'Starbucks', logo_url: 'http://commons.wikimedia.org/wiki/Special:FilePath/Starbucks%20coffee%20wordmark.png', website: 'https://www.starbucks.com/', industry: 'coffee industry', updated_at: '2026-07-08T00:00:00Z' }),
+    JSON.stringify({ qid: 'Q861042', label: 'Western Union', website: 'https://www.westernunion.com', industry: 'financial services' }),
+    '',
+  ].join('\n');
+
+  const service = () => new BrandsEnrichmentService({} as any);
+
+  it('loads NDJSON and serves lookups by QID', () => {
+    const s = service();
+    expect(s.isReady()).toBe(false);
+
+    s.loadFromNdjson(ndjson);
+
+    expect(s.isReady()).toBe(true);
+    expect(s.size()).toBe(2);
+    expect(s.get('Q37158')?.label).toBe('Starbucks');
+    expect(s.get('Q37158')?.logo_url).toContain('commons.wikimedia.org');
+    expect(s.get('Q861042')?.logo_url).toBeUndefined();
+  });
+
+  it('returns undefined for unknown or missing QIDs', () => {
+    const s = service();
+    s.loadFromNdjson(ndjson);
+
+    expect(s.get('Q999999999')).toBeUndefined();
+    expect(s.get(undefined)).toBeUndefined();
+    expect(s.get(null)).toBeUndefined();
+  });
+
+  it('replaces (not merges) data on reload', () => {
+    const s = service();
+    s.loadFromNdjson(ndjson);
+    s.loadFromNdjson(JSON.stringify({ qid: 'Q1', label: 'Only Brand' }));
+
+    expect(s.size()).toBe(1);
+    expect(s.get('Q37158')).toBeUndefined();
+  });
+});

--- a/src/places/brands-enrichment.service.ts
+++ b/src/places/brands-enrichment.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { gunzipSync } from 'zlib';
+import { GcsService } from '../gcs/gcs.service';
+
+export const BRANDS_ENRICHMENT_OBJECT =
+    process.env.BRANDS_ENRICHMENT_OBJECT || 'enrichment/brands-v1.ndjson.gz';
+
+// The artifact is rebuilt monthly; a daily staleness check picks a new build
+// up within a day, matching the divisions search index behaviour.
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export interface BrandEnrichment {
+    qid: string;
+    label?: string;
+    logo_url?: string;
+    website?: string;
+    industry?: string;
+    parent?: string;
+    updated_at?: string;
+}
+
+/**
+ * In-memory Wikidata brand enrichment (~3k rows, CC0-licensed). Loaded from a
+ * gzipped NDJSON artifact in GCS that `npm run etl:brands-enrichment`
+ * rebuilds monthly. Serving is a zero-cost Map lookup by QID; when the
+ * artifact is missing or fails to load, isReady() stays false and responses
+ * simply omit the ext_ brand fields — a pure additive optimisation with no
+ * availability risk.
+ */
+@Injectable()
+export class BrandsEnrichmentService implements OnModuleInit, OnModuleDestroy {
+    logger = new Logger('BrandsEnrichmentService');
+
+    private brands = new Map<string, BrandEnrichment>();
+    private ready = false;
+    private loading = false;
+    private loadedGeneration: string | null = null;
+    private refreshTimer?: NodeJS.Timeout;
+
+    constructor(private readonly gcsService: GcsService) { }
+
+    onModuleInit() {
+        if (process.env.NODE_ENV === 'test' || process.env.BRANDS_ENRICHMENT_ENABLED === 'false') {
+            return;
+        }
+        void this.loadIfStale();
+        this.refreshTimer = setInterval(() => void this.loadIfStale(), REFRESH_INTERVAL_MS);
+        this.refreshTimer.unref?.();
+    }
+
+    onModuleDestroy() {
+        if (this.refreshTimer) clearInterval(this.refreshTimer);
+    }
+
+    isReady(): boolean {
+        return this.ready;
+    }
+
+    get(qid: string | undefined | null): BrandEnrichment | undefined {
+        if (!qid) return undefined;
+        return this.brands.get(qid);
+    }
+
+    size(): number {
+        return this.brands.size;
+    }
+
+    async loadIfStale(): Promise<void> {
+        if (this.loading) return;
+        this.loading = true;
+        try {
+            const generation = await this.gcsService.getObjectGeneration(BRANDS_ENRICHMENT_OBJECT);
+            if (!generation) {
+                this.logger.warn(`Brands enrichment artifact not found in GCS (${BRANDS_ENRICHMENT_OBJECT}); brand ext_ fields disabled. Run "npm run etl:brands-enrichment" to build it.`);
+                return;
+            }
+            if (generation === this.loadedGeneration) return;
+
+            const compressed = await this.gcsService.downloadObject(BRANDS_ENRICHMENT_OBJECT);
+            if (!compressed) return;
+
+            this.loadFromNdjson(gunzipSync(compressed).toString('utf8'));
+            this.loadedGeneration = generation;
+            this.logger.log(`Brands enrichment loaded: ${this.brands.size} brands (GCS generation ${generation})`);
+        } catch (error) {
+            this.logger.error(`Failed to load brands enrichment: ${error.message}`);
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    /** Exposed for tests and for loading from a local artifact. */
+    loadFromNdjson(ndjson: string): void {
+        const brands = new Map<string, BrandEnrichment>();
+        for (const line of ndjson.split('\n')) {
+            if (!line) continue;
+            const row = JSON.parse(line) as BrandEnrichment;
+            if (row.qid) brands.set(row.qid, row);
+        }
+        this.brands = brands;
+        this.ready = brands.size > 0;
+    }
+}

--- a/src/places/dto/models/brand.dto.ts
+++ b/src/places/dto/models/brand.dto.ts
@@ -33,6 +33,23 @@ export class BrandDto {
   })
   names: BrandNamesDto;
 
+  @ApiPropertyOptional({ description: 'Wikidata QID of the brand.', example: 'Q37158' })
+  wikidata?: string;
+
+  @ApiPropertyOptional({ description: 'Brand logo URL (Wikimedia Commons, resizable with ?width=N). Sourced from Wikidata (CC0).', example: 'http://commons.wikimedia.org/wiki/Special:FilePath/Starbucks%20coffee%20wordmark.png' })
+  ext_logo_url?: string;
+
+  @ApiPropertyOptional({ description: 'Official brand website. Sourced from Wikidata (CC0).', example: 'https://www.starbucks.com/' })
+  ext_website?: string;
+
+  @ApiPropertyOptional({ description: 'Industry of the brand. Sourced from Wikidata (CC0).', example: 'coffee industry' })
+  ext_industry?: string;
+
+  @ApiPropertyOptional({ description: 'Parent organisation of the brand. Sourced from Wikidata (CC0).', example: 'Starbucks Corporation' })
+  ext_parent?: string;
+
+  @ApiPropertyOptional({ description: 'English label of the brand on Wikidata (CC0).', example: 'Starbucks' })
+  ext_wikidata_label?: string;
 
   constructor(data: Brand) {
     Object.assign(this, data);

--- a/src/places/dto/requests/get-places.dto.ts
+++ b/src/places/dto/requests/get-places.dto.ts
@@ -108,8 +108,8 @@ export class GetPlacesDto extends GetByLocationDto {
   operating_status?: string;
 
   @ApiPropertyOptional({
-    description: 'Comma-separated list of enrichment fields to include.',
-    example: 'wikidata,extra_info',
+    description: 'Comma-separated list of enrichment fields to include. Use "brand" for Wikidata-sourced brand details (logo, website, industry, parent) on branded places.',
+    example: 'brand',
     type: String,
   })
   @IsOptional()

--- a/src/places/dto/responses/place-response.dto.ts
+++ b/src/places/dto/responses/place-response.dto.ts
@@ -145,6 +145,17 @@ export class PlacePropertiesDto {
     distance:number
   }
 
+  @ApiPropertyOptional({
+    description: 'Wikidata-sourced brand details (CC0). Present when enrichment_fields includes "brand" and the place has a brand with a Wikidata QID.',
+  })
+  ext_brand?: {
+    label?: string;
+    logo_url?: string;
+    website?: string;
+    industry?: string;
+    parent?: string;
+  }
+
   ext_place_geometry?:Point;
 
   constructor(data={}) {

--- a/src/places/enrichment-merge.spec.ts
+++ b/src/places/enrichment-merge.spec.ts
@@ -15,7 +15,7 @@ describe('PlacesController enrichment merge', () => {
       addresses: [],
     };
     const placesService = { getPlaces: jest.fn().mockResolvedValue([samplePlace]) } as unknown as PlacesService;
-    const controller = new PlacesController(placesService, {} as BuildingsService);
+    const controller = new PlacesController(placesService, {} as BuildingsService, { isReady: () => false, get: () => undefined } as any);
     controller['enrichmentAdapter'] = {
       fetchEnrichmentByIds: async () => ({ '1': { foo: 'bar' } }),
       supportedFields: async () => [],

--- a/src/places/places.controller.ts
+++ b/src/places/places.controller.ts
@@ -22,6 +22,7 @@ import { GetPlacesWithBuildingsDto } from './dto/requests/get-places-with-buildi
 import { CountHeader } from '../decorators/count-header.decorator';
 import { loadEnrichmentAdapter } from '../data-adapters/loadEnrichmentAdapter';
 import { EnrichmentAdapter } from '../data-adapters/EnrichmentAdapter';
+import { BrandsEnrichmentService } from './brands-enrichment.service';
 
 @ApiTags('Places')
 @ApiSecurity('API_KEY') // Applies the API key security scheme defined in Swagger
@@ -33,7 +34,8 @@ export class PlacesController {
   
   constructor(
     private placesService: PlacesService,
-    private buildingsService: BuildingsService
+    private buildingsService: BuildingsService,
+    private brandsEnrichment: BrandsEnrichmentService,
 
   ) {}
 
@@ -53,8 +55,27 @@ export class PlacesController {
     const dtoResults = results.map((place: any) =>toPlaceDto(place,query));
 
     let finalResults = dtoResults;
+
+    // `brand` is served from the in-memory Wikidata artifact, not the hosted
+    // enrichment adapter, so peel it off before the adapter call.
+    const requestedFields = query.enrichment_fields ?? [];
+    if (requestedFields.includes('brand') && this.brandsEnrichment.isReady()) {
+      finalResults = finalResults.map((p) => {
+        const enrichment = this.brandsEnrichment.get((p.properties as any)?.brand?.wikidata);
+        if (!enrichment) return p;
+        p.properties.ext_brand = {
+          label: enrichment.label,
+          logo_url: enrichment.logo_url,
+          website: enrichment.website,
+          industry: enrichment.industry,
+          parent: enrichment.parent,
+        };
+        return p;
+      });
+    }
+
     try {
-      const fields = query.enrichment_fields;
+      const fields = requestedFields.filter((f) => f !== 'brand');
       if (fields && fields.length) {
         const ids = dtoResults.map((p) => p.id);
         const enrichment = await this.enrichmentAdapter.fetchEnrichmentByIds(ids, { fields });

--- a/src/places/places.module.ts
+++ b/src/places/places.module.ts
@@ -8,11 +8,13 @@ import { PlacesController } from './places.controller';
 import { BigQueryService } from '../bigquery/bigquery.service';
 import { ConfigModule } from '@nestjs/config';
 import { BuildingsModule } from '../buildings/buildings.module';
+import { BrandsEnrichmentService } from './brands-enrichment.service';
+import { GcsService } from '../gcs/gcs.service';
 
 @Module({
     imports: [ConfigModule, BuildingsModule],
     controllers: [PlacesController],
-    providers: [PlacesService, BigQueryService],
+    providers: [PlacesService, BigQueryService, BrandsEnrichmentService, GcsService],
     exports: [PlacesService]
 
 })

--- a/src/places/places.service.spec.ts
+++ b/src/places/places.service.spec.ts
@@ -7,6 +7,7 @@ import { PlaceResponseDto, toPlaceDto } from './dto/responses/place-response.dto
 import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../cache/cache.service';
 import { buildCacheKey, CACHE_TTL_SECONDS } from '../cache/cache-key.util';
+import { BrandsEnrichmentService } from './brands-enrichment.service';
 
 // Mirrors the data-affecting params the service keys on (excludes presentation params).
 const placesKey = (q: GetPlacesDto) =>
@@ -149,6 +150,10 @@ describe('PlacesService', () => {
         {
           provide: CacheService,
           useValue: { get: mockCacheGet, set: mockCacheSet, del: jest.fn() },
+        },
+        {
+          provide: BrandsEnrichmentService,
+          useValue: { isReady: () => false, get: () => undefined },
         },
         {
           provide: Logger,

--- a/src/places/places.service.ts
+++ b/src/places/places.service.ts
@@ -20,16 +20,36 @@ import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../cache/cache.service';
 import { buildCacheKey, CACHE_TTL_SECONDS } from '../cache/cache-key.util';
 import { GetPlacesWithBuildingsDto } from './dto/requests/get-places-with-buildings';
+import { BrandsEnrichmentService } from './brands-enrichment.service';
 
 @Injectable()
 export class PlacesService {
     logger = new Logger('PlacesService');
-    
+
     constructor(
         private readonly configService: ConfigService,
         private readonly bigQueryService: BigQueryService,
         private readonly cacheService: CacheService,
+        private readonly brandsEnrichment: BrandsEnrichmentService,
     ) {}
+
+    /**
+     * Decorates a BrandDto with Wikidata-sourced ext_ fields when the
+     * enrichment artifact is loaded. Applied after the cache layer so
+     * enrichment availability never splits or invalidates cached results.
+     */
+    private toBrandDtoWithEnrichment(brand: any): BrandDto {
+        const dto = new BrandDto(brand);
+        const enrichment = this.brandsEnrichment.get(brand?.wikidata);
+        if (enrichment) {
+            dto.ext_logo_url = enrichment.logo_url;
+            dto.ext_website = enrichment.website;
+            dto.ext_industry = enrichment.industry;
+            dto.ext_parent = enrichment.parent;
+            dto.ext_wikidata_label = enrichment.label;
+        }
+        return dto;
+    }
     async getPlaces(query: GetPlacesDto):Promise<Place[]> {
 
         const { lat, lng, radius,  country, min_confidence, brand_wikidata,brand_name,categories,limit, source, operating_status, taxonomy } = query;
@@ -69,12 +89,12 @@ export class PlacesService {
         const cacheKey = buildCacheKey('get-places-brands', { country, lat, lng, radius, categories });
         const cachedResult = await this.cacheService.get<any[]>(cacheKey);
         if (cachedResult) {
-          return cachedResult.map((brand: any) => new BrandDto(brand));
+          return cachedResult.map((brand: any) => this.toBrandDtoWithEnrichment(brand));
         }
 
         const results = await this.bigQueryService.getBrandsNearby(country, lat, lng, radius, categories);
         await this.cacheService.set(cacheKey, results, CACHE_TTL_SECONDS);
-        return results.map((brand: any) => new BrandDto(brand));
+        return results.map((brand: any) => this.toBrandDtoWithEnrichment(brand));
       }
 
     async getCountries():Promise<CountryResponseDto[]> {


### PR DESCRIPTION
## Summary

Every branded Overture place carries a `brand.wikidata` QID — 1.55M places resolving to just **3,019 distinct brands**. This PR joins those QIDs to Wikidata (CC0-licensed) and surfaces logos, official websites, industry and parent organisation as additive `ext_` fields.

**No breaking changes**: new optional fields only, omitted entirely when the enrichment artifact isn't loaded.

## How it works

- **ETL** (`etl/build-brands-enrichment.ts`, monthly workflow on the 25th): extracts distinct QIDs from BigQuery, resolves them via ~21 batched SPARQL queries, applies sanity gates (Commons-only logo URLs, http(s)-only websites, abort if <90% resolve so a Wikidata outage can't hollow out the artifact), writes gzipped NDJSON (~98KB) to GCS with a dated snapshot for rollback.
- **Serving** (`BrandsEnrichmentService`): in-memory Map loaded from GCS at startup with daily staleness refresh — same pattern as the divisions search index. Lookups are zero-latency and zero-BigQuery-cost. Decoration happens after the cache layer, so cached results are unaffected by enrichment availability.

## API surface

| Endpoint | Behaviour |
|---|---|
| `GET /places/brands` | **On by default** — each brand gains `ext_logo_url`, `ext_website`, `ext_industry`, `ext_parent`, `ext_wikidata_label` (when known) |
| `GET /places?enrichment_fields=brand` | **Opt-in** — branded places gain an `ext_brand` object; `brand` is peeled off before the hosted enrichment adapter so the two systems don't collide |

## Fill rates (measured against all 3,019 QIDs)

| Field | % of brands | % of branded places |
|---|---|---|
| label | 99.2% | 98.9% |
| website | 97.8% | 97.8% |
| logo | 46.1% | **75.2%** (big chains have logos) |
| industry | 55.9% | 74.4% |
| parent | 29.1% | 37.2% |

Ticker (P249) was dropped — 0% fill; brand entities aren't the listed companies.

## Verification

- Build green, 64/64 unit tests passing (new specs for the enrichment service + updated controller/service specs)
- Full ETL run executed against production GCS: artifact live at `enrichment/brands-v1.ndjson.gz` (3,019 brands, 98KB) + dated snapshot
- Compiled service loaded the real artifact: Starbucks / Western Union / McDonald's all resolve with logo + website + industry

## Post-merge

1. Deploy — the API picks up the already-uploaded artifact on startup; `/places/brands` responses gain ext_ fields immediately.
2. Confirm the `Rebuild Brands Enrichment Artifact` workflow runs with existing secrets (same three as the divisions workflow).
3. Docs/dev-portal: document `enrichment_fields=brand` + Wikidata CC0 attribution note (logo files on Commons carry trademark considerations — usage is the customer's responsibility).