### PR TITLE
fix: serve sibling maritime geometry when a division's land geometry is NULL upstream

### DIFF
--- a/src/bigquery/bigquery.service.spec.ts
+++ b/src/bigquery/bigquery.service.spec.ts
@@ -91,6 +91,73 @@ describe('BigQueryService', () => {
     }
   }
 
+  describe('getDivisionById maritime geometry fallback (OvertureMaps/data#540)', () => {
+    const landRowWithoutGeometry = {
+      id: 'ru-land-id',
+      geometry: null,
+      bbox: null,
+      version: 1,
+      sources: { list: [] },
+      subtype: 'country',
+      class: 'land',
+      admin_level: 0,
+      is_land: true,
+      is_territorial: false,
+      division_id: 'ru-division-id',
+      names: { primary: 'Россия' },
+      country: 'RU',
+    };
+    const maritimeSibling = {
+      ...landRowWithoutGeometry,
+      id: 'ru-maritime-id',
+      geometry: { value: 'MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)))' },
+      bbox: { xmin: '0', xmax: '1', ymin: '0', ymax: '1' },
+      class: 'maritime',
+      is_land: false,
+      is_territorial: true,
+    };
+
+    it('serves the maritime sibling geometry when the land record has NULL geometry', async () => {
+      const service = new BigQueryService();
+      service.runQuery = jest.fn()
+        .mockResolvedValueOnce({ rows: [landRowWithoutGeometry], statistics: {} })
+        .mockResolvedValueOnce({ rows: [maritimeSibling], statistics: {} });
+
+      const result = await service.getDivisionById('ru-land-id');
+
+      expect(service.runQuery).toHaveBeenCalledTimes(2);
+      expect((service.runQuery as jest.Mock).mock.calls[1][1]).toEqual({ division_id: 'ru-division-id', id: 'ru-land-id' });
+      expect(result?.geometry).toBeDefined();
+      expect(result?.ext_geometry_source).toBe('maritime');
+      // Identity fields stay from the requested record
+      expect(result?.id).toBe('ru-land-id');
+      expect(result?.class).toBe('land');
+      expect(result?.bbox).toBeDefined();
+    });
+
+    it('does not run the fallback when geometry is present', async () => {
+      const service = new BigQueryService();
+      service.runQuery = jest.fn().mockResolvedValueOnce({ rows: [maritimeSibling], statistics: {} });
+
+      const result = await service.getDivisionById('ru-maritime-id');
+
+      expect(service.runQuery).toHaveBeenCalledTimes(1);
+      expect(result?.ext_geometry_source).toBeUndefined();
+    });
+
+    it('returns the record unflagged when no sibling with geometry exists', async () => {
+      const service = new BigQueryService();
+      service.runQuery = jest.fn()
+        .mockResolvedValueOnce({ rows: [landRowWithoutGeometry], statistics: {} })
+        .mockResolvedValueOnce({ rows: [], statistics: {} });
+
+      const result = await service.getDivisionById('ru-land-id');
+
+      expect(result?.geometry).toBeUndefined();
+      expect(result?.ext_geometry_source).toBeUndefined();
+    });
+  });
+
   describe('runQuery', () => {
     it('should throw and log error if query fails', async () => {
       const service = new TestableBigQueryService();

--- a/src/bigquery/bigquery.service.ts
+++ b/src/bigquery/bigquery.service.ts
@@ -824,7 +824,36 @@ WHERE s.id = @id
 LIMIT 1;`;
 
     const { rows } = await this.runQuery(query, { id });
-    return rows.length ? parseDivisionRow(rows[0]) : null;
+    if (!rows.length) return null;
+
+    const division = parseDivisionRow(rows[0]);
+
+    // Upstream data gap (github.com/OvertureMaps/data/issues/540): a handful
+    // of country-level land records have NULL geometry in the BigQuery mirror
+    // (e.g. Russia, Australia) while their maritime sibling (land + territorial
+    // waters, same division_id) is intact. Fall back to the sibling's geometry
+    // so clients always get a boundary, flagged via ext_geometry_source.
+    if (!division.geometry && rows[0].division_id) {
+      const fallbackQuery = `-- Overture Maps API: Get Division Area geometry fallback (sibling area)
+SELECT
+  *
+FROM
+  \`bigquery-public-data.overture_maps.division_area\` AS s
+WHERE s.division_id = @division_id
+  AND s.id != @id
+  AND s.geometry IS NOT NULL
+ORDER BY s.is_land DESC
+LIMIT 1;`;
+      const { rows: fallbackRows } = await this.runQuery(fallbackQuery, { division_id: rows[0].division_id, id });
+      if (fallbackRows.length) {
+        const sibling = parseDivisionRow(fallbackRows[0]);
+        division.geometry = sibling.geometry;
+        division.bbox = division.bbox ?? sibling.bbox;
+        division.ext_geometry_source = sibling.class ?? 'sibling_area';
+      }
+    }
+
+    return division;
   }
   private buildWhereClauses({
     country,

--- a/src/divisions/dto/responses/division-response.dto.ts
+++ b/src/divisions/dto/responses/division-response.dto.ts
@@ -36,6 +36,8 @@ export class DivisionPropertiesDto {
     is_territorial?: boolean;
     @ApiPropertyOptional({ description: 'ID of the division feature this area belongs to.' })
     division_id?: string;
+    @ApiPropertyOptional({ description: 'Set when this record\'s own geometry is missing upstream and the boundary was served from a sibling area of the same division; the value is the sibling\'s class, e.g. "maritime" (land plus territorial waters).', example: 'maritime' })
+    ext_geometry_source?: string;
 }
 
 export class DivisionDto {

--- a/src/divisions/interfaces/division.interface.ts
+++ b/src/divisions/interfaces/division.interface.ts
@@ -27,4 +27,11 @@ export interface DivisionArea {
     country?: string;
     region?: string;
     ext_distance?: number;
+    /**
+     * Present when the record's own geometry is NULL upstream and the boundary
+     * was taken from a sibling area of the same division — the value is the
+     * sibling's class, e.g. "maritime" (land + territorial waters).
+     * See github.com/OvertureMaps/data/issues/540.
+     */
+    ext_geometry_source?: string;
 }

--- a/src/middleware/auth-api.middleware.spec.ts
+++ b/src/middleware/auth-api.middleware.spec.ts
@@ -5,3 +5,97 @@ describe('AuthApiMiddleware', () => {
     expect(new AuthAPIMiddleware()).toBeDefined();
   });
 });
+
+// Regression tests for the demo API key path. In Jun 2026 a hardening change
+// made TheAuthAPI rejection return 401 *before* the demo-key check ran, which
+// silently disabled the public demo key in production. The demo key must be
+// honoured before any TheAuthAPI call.
+describe('AuthAPIMiddleware demo key handling', () => {
+  const DEMO_KEY = 'TEST-DEMO-KEY';
+  let originalEnv: string | undefined;
+
+  const makeReqRes = (apiKey?: string) => {
+    const locals: any = {};
+    const res: any = {
+      locals,
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+    const req: any = {
+      get: (name: string) => (name === 'X-Api-Key' ? apiKey : undefined),
+      query: {},
+      headers: {},
+      res,
+    };
+    req.res.locals = locals;
+    return { req, res };
+  };
+
+  beforeEach(() => {
+    originalEnv = process.env.DEMO_API_KEY;
+    process.env.DEMO_API_KEY = DEMO_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.DEMO_API_KEY;
+    else process.env.DEMO_API_KEY = originalEnv;
+  });
+
+  it('authenticates the demo key WITHOUT calling TheAuthAPI, even when TheAuthAPI is configured', async () => {
+    const middleware = new AuthAPIMiddleware();
+    const authenticateKey = jest.fn().mockResolvedValue(null); // TheAuthAPI does not know the demo key
+    (middleware as any).theAuthAPI = { apiKeys: { authenticateKey } };
+
+    const { req, res } = makeReqRes(DEMO_KEY);
+    const next = jest.fn();
+    await middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual(expect.objectContaining({ isDemoAccount: true }));
+    expect(authenticateKey).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown keys with 401 when TheAuthAPI does not authenticate them', async () => {
+    const middleware = new AuthAPIMiddleware();
+    (middleware as any).theAuthAPI = { apiKeys: { authenticateKey: jest.fn().mockResolvedValue(null) } };
+
+    const { req, res } = makeReqRes('not-a-real-key');
+    const next = jest.fn();
+    await middleware.use(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('does NOT accept the well-known literal when DEMO_API_KEY is unset (no fallback)', async () => {
+    delete process.env.DEMO_API_KEY;
+    const middleware = new AuthAPIMiddleware();
+    (middleware as any).theAuthAPI = { apiKeys: { authenticateKey: jest.fn().mockResolvedValue(null) } };
+
+    const { req, res } = makeReqRes('DEMO-API-KEY');
+    const next = jest.fn();
+    await middleware.use(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('still authenticates real keys via TheAuthAPI', async () => {
+    const middleware = new AuthAPIMiddleware();
+    const authenticateKey = jest.fn().mockResolvedValue({
+      customMetaData: { isDemoAccount: false },
+      customAccountId: 'acc-1',
+      customUserId: 'user-1',
+    });
+    (middleware as any).theAuthAPI = { apiKeys: { authenticateKey } };
+
+    const { req, res } = makeReqRes('live_real_key');
+    const next = jest.fn();
+    await middleware.use(req, res, next);
+
+    expect(authenticateKey).toHaveBeenCalledWith('live_real_key', undefined);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual(expect.objectContaining({ accountId: 'acc-1', isDemoAccount: false }));
+  });
+});

--- a/src/middleware/auth-api.middleware.ts
+++ b/src/middleware/auth-api.middleware.ts
@@ -13,7 +13,9 @@ const TheAuthAPI = require('theauthapi');
 
 // Only enabled when explicitly configured. No literal fallback so an unset env
 // var can never leave a publicly-known demo credential valid in production.
-const DEMO_API_KEY = process.env.DEMO_API_KEY;
+// Read per-request so tests (and runtime config changes) take effect without
+// a module reload.
+const getDemoApiKey = (): string | undefined => process.env.DEMO_API_KEY;
 
 // Avoid writing raw API keys to logs.
 function maskKey(key?: string): string {
@@ -66,6 +68,23 @@ export class AuthAPIMiddleware implements NestMiddleware {
       return;
     }
 
+    // Demo key first: it's a constant-string compare, saves a TheAuthAPI
+    // round-trip, and must run before the explicit rejection below —
+    // TheAuthAPI doesn't know the demo key, so checking it afterwards means
+    // it can never match (this exact ordering bug shipped in Jun 2026).
+    // Only enabled when DEMO_API_KEY is explicitly configured.
+    const demoApiKey = getDemoApiKey();
+    if (demoApiKey && apiKeyString === demoApiKey) {
+      const demoUser: User = {
+        isDemoAccount: true,
+        accountId: 'demo-account-id',
+        userId: 'demo-user-id'
+      };
+      req['user'] = req.res.locals['user'] = demoUser;
+      next();
+      return;
+    }
+
     try {
 
       // if theAuthAPI.com is integrated, check the key
@@ -97,18 +116,6 @@ export class AuthAPIMiddleware implements NestMiddleware {
         res.status(403).send(error.message || 'Origin domain is not allowed for this API key');
         return;
       }
-    }
-
-    //if demo key, set user to demo user
-    if (DEMO_API_KEY && apiKeyString === DEMO_API_KEY) {
-      const demoUser: User = {
-        isDemoAccount: true,
-        accountId: 'demo-account-id',
-        userId: 'demo-user-id'
-      };
-      req['user'] = req.res.locals['user'] = demoUser;
-      next();
-      return;
     }
 
     //if we got this far and they passed a key we should tell the user their key doesn't work and to check for a spelling mistake


### PR DESCRIPTION
## Summary

A handful of country-level division_area land records (Russia, Australia) have NULL geometry in the BigQuery mirror while their maritime sibling (same division_id, land + territorial waters) is intact — upstream issue OvertureMaps/data#540, confirmed to be a mirror conversion problem (source GeoParquet is valid; CARTO maintains the mirror and is being contacted).

This makes the gap invisible to API clients: GET /divisions/{id} now falls back to the sibling area's geometry when the requested record's own geometry is NULL.

## Behaviour

- Identity fields (id, class, subtype, admin_level, names) stay from the requested record; only geometry (and bbox if missing) come from the sibling
- - The substitution is flagged additively via ext_geometry_source (e.g. "maritime") — records with their own geometry are completely unaffected and unflagged
- - No sibling with geometry: record returned as before, unflagged
- - Uses the division_id column from the schema-2026 update; costs one extra keyed query only on the (currently two) affected records
## Verification

- 71/71 unit tests passing incl. 3 new specs (fallback triggers, doesn't trigger when geometry present, no-sibling case)
- - Live against the mirror: Russia land returns a 3.8MB MultiPolygon and Australia land 694KB, both with ext_geometry_source: "maritime"
## Context

Unblocks Mapme's production migration. When CARTO fixes the mirror, the fallback simply stops triggering and true land boundaries flow through automatically. Note: this PR also carries the demo-key middleware fix commit (c4baefd), which is already live in prod but wasn't yet on origin/main.