### PR TITLE
Return 429 when a key is rate limited, not a misleading 401

### DIFF
--- a/src/middleware/auth-api.middleware.spec.ts
+++ b/src/middleware/auth-api.middleware.spec.ts
@@ -99,3 +99,105 @@ describe('AuthAPIMiddleware demo key handling', () => {
     expect(req.user).toEqual(expect.objectContaining({ accountId: 'acc-1', isDemoAccount: false }));
   });
 });
+
+describe('AuthAPIMiddleware upstream error handling', () => {
+  const makeReqRes = (apiKey?: string) => {
+    const locals: any = {};
+    const res: any = {
+      locals,
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+    const req: any = {
+      get: (name: string) => (name === 'X-Api-Key' ? apiKey : undefined),
+      query: {},
+      headers: {},
+      res,
+    };
+    req.res.locals = locals;
+    return { req, res };
+  };
+
+  // Mirrors TheAuthAPI SDK's ApiResponseError
+  const apiResponseError = (statusCode: number, message: string) => {
+    const error: any = new Error(`(${statusCode}): ${message}`);
+    error.name = 'ApiResponseError';
+    error.statusCode = statusCode;
+    error.message = message;
+    return error;
+  };
+
+  const middlewareThrowing = (error: any) => {
+    const middleware = new AuthAPIMiddleware();
+    (middleware as any).theAuthAPI = {
+      apiKeys: { authenticateKey: jest.fn().mockRejectedValue(error) },
+    };
+    return middleware;
+  };
+
+  it('returns 429 when the key is rate limited, NOT a misleading 401', async () => {
+    const middleware = middlewareThrowing(
+      apiResponseError(429, 'Rate limit exceeded'),
+    );
+    const { req, res } = makeReqRes('live_real_key');
+    const next = jest.fn();
+
+    await middleware.use(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.send).toHaveBeenCalledWith('Rate limit exceeded');
+  });
+
+  it('returns 429 when the monthly quota is exceeded', async () => {
+    const middleware = middlewareThrowing(
+      apiResponseError(429, 'Monthly request quota exceeded'),
+    );
+    const { req, res } = makeReqRes('live_real_key');
+
+    await middleware.use(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.send).toHaveBeenCalledWith('Monthly request quota exceeded');
+  });
+
+  it('still returns 403 for a disallowed origin domain', async () => {
+    const middleware = middlewareThrowing(
+      apiResponseError(403, 'Origin domain is not allowed for this API key'),
+    );
+    const { req, res } = makeReqRes('live_real_key');
+
+    await middleware.use(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 503 when TheAuthAPI is erroring, rather than blaming the key', async () => {
+    const middleware = middlewareThrowing(
+      apiResponseError(500, 'Internal Server Error'),
+    );
+    const { req, res } = makeReqRes('live_real_key');
+
+    await middleware.use(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(503);
+  });
+
+  it('returns 503 when TheAuthAPI is unreachable (no status on the error)', async () => {
+    const middleware = middlewareThrowing(new Error('connect ECONNREFUSED'));
+    const { req, res } = makeReqRes('live_real_key');
+
+    await middleware.use(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(503);
+  });
+
+  it('still returns 401 for a genuinely unknown key (404 upstream)', async () => {
+    const middleware = middlewareThrowing(apiResponseError(404, 'Not Found'));
+    const { req, res } = makeReqRes('live_wrong_key');
+
+    await middleware.use(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});

--- a/src/middleware/auth-api.middleware.ts
+++ b/src/middleware/auth-api.middleware.ts
@@ -112,8 +112,32 @@ export class AuthAPIMiddleware implements NestMiddleware {
       }
     } catch (error: any) {
       Logger.error('APIKeyMiddleware Error:', error, ` key: ${maskKey(apiKeyString)}`);
-      if (error && (error.statusCode === 403 || error.status === 403 || error.response?.status === 403)) {
+
+      // TheAuthAPI's SDK throws ApiResponseError carrying the upstream HTTP
+      // status. Surface the ones that mean something specific to the caller
+      // rather than collapsing them all into "check your spelling".
+      const status = getUpstreamStatus(error);
+
+      if (status === 403) {
         res.status(403).send(error.message || 'Origin domain is not allowed for this API key');
+        return;
+      }
+
+      // The key is valid but over its rate limit or monthly quota. Telling
+      // the caller their key is misspelled here is actively misleading.
+      if (status === 429) {
+        res
+          .status(429)
+          .send(error.message || 'Rate limit exceeded - too many requests for this API key');
+        return;
+      }
+
+      // TheAuthAPI is unreachable or erroring: this is our problem, not a bad
+      // key. A 401 would send customers hunting for a typo during an outage.
+      if (status === undefined || status >= 500) {
+        res
+          .status(503)
+          .send('Unable to verify your API key right now - please retry shortly');
         return;
       }
     }
@@ -122,4 +146,10 @@ export class AuthAPIMiddleware implements NestMiddleware {
     res.status(401).send('Unauthorized - check the spelling of your API Key');
     return;
   }
+}
+
+// The status may arrive as ApiResponseError.statusCode, or on an axios-shaped
+// error, depending on where it was thrown.
+function getUpstreamStatus(error: any): number | undefined {
+  return error?.statusCode ?? error?.status ?? error?.response?.status;
 }


### PR DESCRIPTION
The auth middleware only special-cased 403, so every other upstream error from TheAuthAPI collapsed into 'Unauthorized - check the spelling of your API Key'. A client over its per-minute rate limit or monthly quota was told its key was misspelled, and during a TheAuthAPI outage every customer got the same message.

TheAuthAPI's SDK throws ApiResponseError carrying the upstream status, so we have what we need:
- 429 -> 429 with the upstream message (rate limit / monthly quota)
- 403 -> 403 (unchanged, disallowed origin)
- 5xx or unreachable -> 503, since that is our fault not the key's
- 404/anything else -> 401 (genuinely unknown key)