### PR TITLE
Strip the SDK status prefix from rate-limit messages

### DIFF
--- a/src/middleware/auth-api.middleware.spec.ts
+++ b/src/middleware/auth-api.middleware.spec.ts
@@ -149,6 +149,20 @@ describe('AuthAPIMiddleware upstream error handling', () => {
     expect(res.send).toHaveBeenCalledWith('Rate limit exceeded');
   });
 
+  it('strips the SDK status prefix from the message it passes on', async () => {
+    // The real SDK message looks like "(429): Too many requests"
+    const error: any = new Error('(429): Too many requests');
+    error.statusCode = 429;
+    error.message = '(429): Too many requests';
+    const middleware = middlewareThrowing(error);
+    const { req, res } = makeReqRes('live_real_key');
+
+    await middleware.use(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.send).toHaveBeenCalledWith('Too many requests');
+  });
+
   it('returns 429 when the monthly quota is exceeded', async () => {
     const middleware = middlewareThrowing(
       apiResponseError(429, 'Monthly request quota exceeded'),

--- a/src/middleware/auth-api.middleware.ts
+++ b/src/middleware/auth-api.middleware.ts
@@ -126,9 +126,7 @@ export class AuthAPIMiddleware implements NestMiddleware {
       // The key is valid but over its rate limit or monthly quota. Telling
       // the caller their key is misspelled here is actively misleading.
       if (status === 429) {
-        res
-          .status(429)
-          .send(error.message || 'Rate limit exceeded - too many requests for this API key');
+        res.status(429).send(cleanUpstreamMessage(error.message, 'Too many requests - rate limit exceeded for this API key'));
         return;
       }
 
@@ -152,4 +150,11 @@ export class AuthAPIMiddleware implements NestMiddleware {
 // error, depending on where it was thrown.
 function getUpstreamStatus(error: any): number | undefined {
   return error?.statusCode ?? error?.status ?? error?.response?.status;
+}
+
+// TheAuthAPI's SDK prefixes its messages with the status, e.g.
+// "(429): Too many requests". Strip that so callers get a clean sentence.
+function cleanUpstreamMessage(message: string | undefined, fallback: string): string {
+  const stripped = message?.replace(/^\(\d{3}\):\s*/, '').trim();
+  return stripped || fallback;
 }


### PR DESCRIPTION
Clients were seeing '(429): Too many requests' - the ApiResponseError message format leaking through. Send the plain sentence instead.