### PR TITLE
Add has_contact filter to /places (website/phone/email/social presence)

### DIFF
--- a/src/bigquery/bigquery.service.spec.ts
+++ b/src/bigquery/bigquery.service.spec.ts
@@ -108,6 +108,32 @@ describe('BigQueryService', () => {
       expect(sql).toContain('EXISTS (SELECT 1 FROM UNNEST(sources) AS s WHERE s.dataset = @source)');
       expect(params.source).toBe('meta');
     });
+
+    it('filters to places with a website when has_contact=[website]', async () => {
+      const service = new BigQueryService();
+      service.runQuery = jest.fn().mockResolvedValue({ rows: [validRow], statistics: {} });
+      const spy = jest.spyOn(service, 'runQuery');
+      await service.getPlacesNearby(10, 20, 500, undefined, undefined, 'GB', undefined, 0.5, 5, undefined, undefined, undefined, 0, ['website']);
+      const sql = spy.mock.calls[0][0];
+      expect(sql).toContain('(ARRAY_LENGTH(websites.list) > 0)');
+    });
+
+    it('uses OR semantics across multiple has_contact fields', async () => {
+      const service = new BigQueryService();
+      service.runQuery = jest.fn().mockResolvedValue({ rows: [validRow], statistics: {} });
+      const spy = jest.spyOn(service, 'runQuery');
+      await service.getPlacesNearby(10, 20, 500, undefined, undefined, 'GB', undefined, 0.5, 5, undefined, undefined, undefined, 0, ['website', 'social']);
+      const sql = spy.mock.calls[0][0];
+      expect(sql).toContain('(ARRAY_LENGTH(websites.list) > 0 OR ARRAY_LENGTH(socials.list) > 0)');
+    });
+
+    it('adds no contact clause when has_contact is empty or omitted', async () => {
+      const service = new BigQueryService();
+      service.runQuery = jest.fn().mockResolvedValue({ rows: [validRow], statistics: {} });
+      const spy = jest.spyOn(service, 'runQuery');
+      await service.getPlacesNearby(10, 20, 500, undefined, undefined, 'GB', undefined, 0.5, 5, undefined, undefined, undefined, 0, []);
+      expect(spy.mock.calls[0][0]).not.toContain('ARRAY_LENGTH');
+    });
   });
 
   // Helper to expose bigQueryClient for testing

--- a/src/bigquery/bigquery.service.ts
+++ b/src/bigquery/bigquery.service.ts
@@ -107,6 +107,30 @@ export class BigQueryService {
     return `(${prefix}taxonomy.primary IN UNNEST(@taxonomy) OR EXISTS(SELECT 1 FROM UNNEST(${prefix}taxonomy.hierarchy.list) AS th WHERE th.element IN UNNEST(@taxonomy)))`;
   }
 
+  // Maps a public has_contact value to its Overture array column. Contact
+  // columns are Parquet-style repeated fields (STRUCT<list ARRAY<..>>), so
+  // presence is ARRAY_LENGTH(col.list) > 0. NULL columns yield NULL (excluded).
+  private static readonly CONTACT_COLUMNS: Record<string, string> = {
+    website: 'websites',
+    phone: 'phones',
+    email: 'emails',
+    social: 'socials',
+  };
+
+  /**
+   * "At least one of the requested contact fields is present" — OR semantics,
+   * so has_contact=website,social matches places with a website OR a social.
+   * Values are DTO-validated against CONTACT_COLUMNS keys; unknown values are
+   * ignored defensively.
+   */
+  private contactPresenceSql(fields: string[], prefix = ''): string | null {
+    const clauses = fields
+      .map((f) => BigQueryService.CONTACT_COLUMNS[f])
+      .filter(Boolean)
+      .map((col) => `ARRAY_LENGTH(${prefix}${col}.list) > 0`);
+    return clauses.length ? `(${clauses.join(' OR ')})` : null;
+  }
+
   /**
    * Appends LIMIT/OFFSET for pagination. Used together with a
    * `COUNT(*) OVER() AS total_count` window aggregate in the SELECT list so a
@@ -429,7 +453,8 @@ export class BigQueryService {
     source?: string,
     operating_status?: string,
     taxonomy?: string[],
-    page: number = 0
+    page: number = 0,
+    has_contact?: string[]
   ): Promise<{ results: Place[]; totalCount: number }> {
 
     let queryParts: string[] = [];
@@ -494,6 +519,11 @@ export class BigQueryService {
       // Filter for at least one sources element with matching dataset
       whereClauses.push(`EXISTS (SELECT 1 FROM UNNEST(sources) AS s WHERE s.dataset = @source)`);
       params.source = source;
+    }
+
+    if (has_contact && has_contact.length > 0) {
+      const contactSql = this.contactPresenceSql(has_contact);
+      if (contactSql) whereClauses.push(contactSql);
     }
 
     // Combine where clauses

--- a/src/places/dto/requests/get-places.dto.ts
+++ b/src/places/dto/requests/get-places.dto.ts
@@ -117,6 +117,18 @@ export class GetPlacesDto extends GetByLocationDto {
   enrichment_fields?: string[];
 
   @ApiPropertyOptional({
+    description:
+      'Return only places that already have at least one of the listed contact fields. Comma-separated, matched with OR: e.g. "website" returns places with a website; "website,social" returns places with a website OR a social link. Useful for filtering to businesses you can verify. Allowed values: website, phone, email, social.',
+    example: 'website,social',
+    type: String,
+  })
+  @IsOptional()
+  @Transform((params) => String(params.value).split(',').map((s) => s.trim().toLowerCase()).filter(Boolean))
+  @IsArray()
+  @IsIn(['website', 'phone', 'email', 'social'], { each: true })
+  has_contact?: string[];
+
+  @ApiPropertyOptional({
     description: 'Response format, defaulting to JSON. Options are "json", "csv", or "geojson".',
     example: 'json',
     default: 'json',

--- a/src/places/places.service.spec.ts
+++ b/src/places/places.service.spec.ts
@@ -229,7 +229,8 @@ describe('PlacesService', () => {
       undefined, // source (applied post-query)
       undefined, // operating_status
       undefined, // taxonomy
-      0          // page
+      0,         // page
+      undefined  // has_contact
     );
 
     expect(mockCacheSet).toHaveBeenCalledWith(placesKey(query), paginatedResponse, CACHE_TTL_SECONDS);

--- a/src/places/places.service.ts
+++ b/src/places/places.service.ts
@@ -52,11 +52,11 @@ export class PlacesService {
     }
     async getPlaces(query: GetPlacesDto):Promise<{ results: Place[]; totalCount: number }> {
 
-        const { lat, lng, radius,  country, min_confidence, brand_wikidata,brand_name,categories,limit, page = 0, source, operating_status, taxonomy } = query;
+        const { lat, lng, radius,  country, min_confidence, brand_wikidata,brand_name,categories,limit, page = 0, source, operating_status, taxonomy, has_contact } = query;
         // Key on data-affecting params only. `source` is applied as a post-query
         // filter below, so it must not split the cache. Page 0 keeps the
         // pre-pagination key so warm cache entries stay useful.
-        const cacheKey = buildCacheKey('get-places', { lat, lng, radius, country, min_confidence, brand_wikidata, brand_name, categories, limit, operating_status, taxonomy, page: page > 0 ? page : undefined });
+        const cacheKey = buildCacheKey('get-places', { lat, lng, radius, country, min_confidence, brand_wikidata, brand_name, categories, limit, operating_status, taxonomy, has_contact, page: page > 0 ? page : undefined });
         let cached = await this.cacheService.get<any>(cacheKey);
         // Entries cached before pagination shipped are plain arrays; wrap them
         // so they stay valid until their TTL expires.
@@ -64,7 +64,7 @@ export class PlacesService {
           cached = { results: cached, totalCount: cached.length };
         }
         if (!cached?.results) {
-          cached = await this.bigQueryService.getPlacesNearby(lat, lng, radius, brand_wikidata, brand_name, country, categories, min_confidence, limit, undefined, operating_status, taxonomy, page);
+          cached = await this.bigQueryService.getPlacesNearby(lat, lng, radius, brand_wikidata, brand_name, country, categories, min_confidence, limit, undefined, operating_status, taxonomy, page, has_contact);
           await this.cacheService.set(cacheKey, cached, CACHE_TTL_SECONDS);
         }
         // Filter by source if provided (post-query filter: totalCount stays the


### PR DESCRIPTION
Returns only places that already have at least one of the listed contact fields, matched with OR: has_contact=website returns places with a website; has_contact=website,social returns website OR social. Lets callers filter to businesses they can actually verify/enrich, instead of paging through records with no contact info.

SQL is ARRAY_LENGTH(<col>.list) > 0 per field (NULL columns excluded); values are DTO-validated against website/phone/email/social. Threaded through getPlaces and the cache key. Unit tests cover single field, OR across fields, and the empty/omitted case.